### PR TITLE
Add Firebase lobby scaffold with passcode auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# pasf
+# StickFight Firebase MVP
+
+Prototype lobby and admin tools for the StickFight brief. This repo provides a Vite + TypeScript scaffold with Firebase Authentication and Firestore helpers for player passcodes, arenas, and presence tracking.
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `firestore.rules` into your Firebase project or emulator.
+3. Start the Vite dev server:
+   ```bash
+   npm run dev
+   ```
+4. Open the pages directly:
+   - `/index.html` – player login and arena list
+   - `/arena.html?arena=<arenaId>` – placeholder arena view
+   - `/admin.html` – temporary boss tools (development only)
+
+> **Note:** Anonymous auth is used for all sessions. Passcodes map to player documents through `passcodes/{passcode}`. Security rules are intentionally permissive for development and must be hardened before launch.
+
+## Firestore data model
+
+- `meta/config`
+  - `bossNote`: informational text for the boss dashboard
+- `players/{playerId}`
+  - `name`, `passcodeId`, `stats`, optional `settings`
+- `passcodes/{passcode}`
+  - Stores `playerId`
+- `arenas/{arenaId}`
+  - `name`, `active`
+  - `presence/{playerId}` subcollection for occupants
+
+## Development notes
+
+- `src/firebase.ts` bootstraps Firebase and anonymous auth helpers.
+- `src/db.ts` centralizes reads/writes for Firestore collections.
+- `src/auth.ts` keeps the cached player identity in local storage.
+- Front-end scripts under `public/` use lightweight DOM scaffolds so gameplay wiring can be added later.
+- `firestore.rules` exposes permissive read/write access for authenticated clients (anonymous included). Harden in a later brief.
+
+Run formatting and linting through your preferred tools. No automated checks are configured yet.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,30 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Anyone with an anonymous session can read basic game data
+    match /arenas/{arenaId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null; // TEMP: allow creating/deleting arenas in dev
+      match /presence/{playerId} {
+        allow read, write: if request.auth != null; // TEMP
+      }
+    }
+
+    match /players/{playerId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null; // TEMP: Boss writes via admin page in dev
+    }
+
+    // Passcode lookup: readable if you already know the passcode id
+    match /passcodes/{passcode} {
+      allow read: if request.auth != null;      // TEMP
+      allow write: if request.auth != null;     // TEMP
+    }
+
+    match /meta/{doc} {
+      allow read: if true;
+      allow write: if false;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stickfight",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "firebase": "^10.12.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StickFight Admin (Dev Only)</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>StickFight Boss Console</h1>
+      <div class="alert">
+        <strong>DEV ONLY — Do not share this page.</strong>
+        <p class="notice">
+          Temporary tools for loading players and arenas while we build the secure admin flow.
+        </p>
+      </div>
+    </header>
+
+    <main>
+      <section>
+        <h2>Create Player</h2>
+        <form id="player-form">
+          <label for="player-name">Player Name</label>
+          <input id="player-name" name="player" required />
+          <label for="player-passcode">Passcode</label>
+          <input id="player-passcode" name="passcode" minlength="6" required />
+          <button type="submit">Create Player</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Current Players</h2>
+        <div id="player-list" class="card-list"></div>
+      </section>
+
+      <section>
+        <h2>Create Arena</h2>
+        <form id="arena-form">
+          <label for="arena-name">Arena Name</label>
+          <input id="arena-name" name="arena" required />
+          <button type="submit">Create Arena</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Current Arenas</h2>
+        <div id="arena-list" class="card-list"></div>
+      </section>
+    </main>
+
+    <script type="module" src="./admin.js"></script>
+  </body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,123 @@
+// @ts-check
+import { ensureAnonAuth } from "../src/firebase.ts";
+import {
+  bossCreatePlayer,
+  bossDeletePlayerById,
+  bossCreateArena,
+  bossDeleteArena,
+  listPlayers,
+  listArenas
+} from "../src/db.ts";
+
+// TODO: Lock these operations behind secure admin flows via Cloud Functions.
+await ensureAnonAuth();
+
+const playerForm = /** @type {HTMLFormElement | null} */ (document.querySelector("#player-form"));
+const playerList = /** @type {HTMLElement | null} */ (document.querySelector("#player-list"));
+const arenaForm = /** @type {HTMLFormElement | null} */ (document.querySelector("#arena-form"));
+const arenaList = /** @type {HTMLElement | null} */ (document.querySelector("#arena-list"));
+
+async function refreshPlayers() {
+  if (!playerList) return;
+  const players = await listPlayers();
+  playerList.innerHTML = "";
+  if (!players.length) {
+    const empty = document.createElement("p");
+    empty.textContent = "No players yet.";
+    playerList.appendChild(empty);
+    return;
+  }
+  players.forEach((player) => {
+    const card = document.createElement("div");
+    card.className = "card";
+    const title = document.createElement("h3");
+    title.textContent = player.name;
+    card.appendChild(title);
+
+    const passcode = document.createElement("p");
+    passcode.textContent = `Passcode ID: ${player.passcodeId ?? "?"}`;
+    card.appendChild(passcode);
+
+    const stats = document.createElement("p");
+    const wins = player.stats?.wins ?? 0;
+    const losses = player.stats?.losses ?? 0;
+    stats.textContent = `Record: ${wins}-${losses}`;
+    card.appendChild(stats);
+
+    const remove = document.createElement("button");
+    remove.textContent = "Delete";
+    remove.addEventListener("click", async () => {
+      if (!confirm(`Remove ${player.name}?`)) return;
+      await bossDeletePlayerById(player.id);
+      await refreshPlayers();
+    });
+    card.appendChild(remove);
+
+    playerList.appendChild(card);
+  });
+}
+
+async function refreshArenas() {
+  if (!arenaList) return;
+  const arenas = await listArenas();
+  arenaList.innerHTML = "";
+  if (!arenas.length) {
+    const empty = document.createElement("p");
+    empty.textContent = "No arenas created yet.";
+    arenaList.appendChild(empty);
+    return;
+  }
+  arenas.forEach((arena) => {
+    const card = document.createElement("div");
+    card.className = "card";
+    const title = document.createElement("h3");
+    title.textContent = arena.name;
+    card.appendChild(title);
+
+    const status = document.createElement("p");
+    status.textContent = arena.active ? "Active" : "Inactive";
+    card.appendChild(status);
+
+    const population = document.createElement("p");
+    population.textContent = `Fighters inside: ${arena.presence.length}`;
+    card.appendChild(population);
+
+    const remove = document.createElement("button");
+    remove.textContent = "Delete";
+    remove.addEventListener("click", async () => {
+      if (!confirm(`Delete arena ${arena.name}?`)) return;
+      await bossDeleteArena(arena.id);
+      await refreshArenas();
+    });
+    card.appendChild(remove);
+
+    arenaList.appendChild(card);
+  });
+}
+
+if (playerForm) {
+  playerForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const formData = new FormData(playerForm);
+    const name = String(formData.get("player") ?? "").trim();
+    const passcode = String(formData.get("passcode") ?? "").trim();
+    if (!name || !passcode) return;
+    await bossCreatePlayer(name, passcode);
+    playerForm.reset();
+    await refreshPlayers();
+  });
+}
+
+if (arenaForm) {
+  arenaForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const formData = new FormData(arenaForm);
+    const name = String(formData.get("arena") ?? "").trim();
+    if (!name) return;
+    await bossCreateArena(name);
+    arenaForm.reset();
+    await refreshArenas();
+  });
+}
+
+await Promise.all([refreshPlayers(), refreshArenas()]);

--- a/public/arena.html
+++ b/public/arena.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StickFight Arena</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1 id="arena-title">Arena</h1>
+      <p class="notice">
+        Placeholder arena view. Gameplay sync arrives in a later brief.
+      </p>
+    </header>
+
+    <main>
+      <section>
+        <h2>Fighters in this arena</h2>
+        <div id="presence" class="card-list"></div>
+      </section>
+
+      <section>
+        <button id="leave-btn" class="large-button">Exit Arena</button>
+      </section>
+    </main>
+
+    <script type="module" src="./arena.js"></script>
+  </body>
+</html>

--- a/public/arena.js
+++ b/public/arena.js
@@ -1,0 +1,80 @@
+// @ts-check
+import { ensureAnonAuth } from "../src/firebase.ts";
+import {
+  joinArena,
+  leaveArena,
+  getArena,
+  listenToArenaPresence
+} from "../src/db.ts";
+import { getCachedPlayer } from "../src/auth.ts";
+
+const params = new URLSearchParams(window.location.search);
+const arenaId = params.get("arena");
+const titleEl = /** @type {HTMLElement | null} */ (document.querySelector("#arena-title"));
+const presenceList = /** @type {HTMLElement | null} */ (document.querySelector("#presence"));
+const leaveBtn = /** @type {HTMLButtonElement | null} */ (document.querySelector("#leave-btn"));
+
+const player = getCachedPlayer();
+
+if (!arenaId) {
+  alert("Missing arena id. Returning to lobby.");
+  window.location.href = "./index.html";
+}
+
+if (!player) {
+  alert("Please log in first.");
+  window.location.href = "./index.html";
+}
+
+/** @type {null | (() => void)} */
+let unsubscribe = null;
+
+async function setup() {
+  if (!arenaId || !player) return;
+  await ensureAnonAuth();
+  const arena = await getArena(arenaId);
+  if (!arena) {
+    alert("Arena not found. Returning to lobby.");
+    window.location.href = "./index.html";
+    return;
+  }
+  if (titleEl) {
+    titleEl.textContent = `${arena.name} (${arena.id.slice(0, 6)})`;
+  }
+  await joinArena(arenaId, player.playerId, player.name);
+  unsubscribe = listenToArenaPresence(arenaId, (presence) => {
+    if (!presenceList) return;
+    presenceList.innerHTML = "";
+    if (!presence.length) {
+      const empty = document.createElement("p");
+      empty.textContent = "You are the first fighter here!";
+      presenceList.appendChild(empty);
+      return;
+    }
+    presence.forEach((member) => {
+      const card = document.createElement("div");
+      card.className = "card";
+      const name = document.createElement("h3");
+      name.textContent = member.playerName;
+      card.appendChild(name);
+      presenceList.appendChild(card);
+    });
+  });
+}
+
+if (leaveBtn) {
+  leaveBtn.addEventListener("click", async () => {
+    if (!arenaId || !player) return;
+    await leaveArena(arenaId, player.playerId);
+    window.location.href = "./index.html";
+  });
+}
+
+window.addEventListener("beforeunload", () => {
+  if (unsubscribe) unsubscribe();
+  if (arenaId && player) {
+    void leaveArena(arenaId, player.playerId);
+  }
+});
+
+await setup();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StickFight - Player Lobby</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>StickFight Training Grounds</h1>
+      <p class="notice">
+        Enter your secret passcode to join battles. Keep it safe!
+      </p>
+    </header>
+
+    <section id="login-card">
+      <form id="login-form">
+        <label for="passcode-input">Player Passcode</label>
+        <input id="passcode-input" name="passcode" type="password" minlength="6" required />
+        <button type="submit" class="large-button">Login</button>
+        <p id="login-status" class="notice"></p>
+      </form>
+    </section>
+
+    <main id="dashboard" hidden>
+      <section>
+        <h2>Welcome, <span id="player-name"></span>!</h2>
+        <div class="actions">
+          <button id="quick-match" class="large-button">Quick Match</button>
+          <button id="logout-btn">Log out</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Arenas</h2>
+        <div id="arenas" class="card-list"></div>
+      </section>
+    </main>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/public/index.js
+++ b/public/index.js
@@ -1,0 +1,172 @@
+// @ts-check
+import { ensureAnonAuth } from "../src/firebase.ts";
+import {
+  resolvePasscode,
+  listenToArenas,
+  joinArena
+} from "../src/db.ts";
+/** @typedef {import("../src/db.ts").ArenaSummary} ArenaSummary */
+import { getCachedPlayer, cachePlayer, clearCachedPlayer } from "../src/auth.ts";
+
+await ensureAnonAuth();
+
+const loginForm = /** @type {HTMLFormElement | null} */ (document.querySelector("#login-form"));
+const passcodeInput = /** @type {HTMLInputElement | null} */ (document.querySelector("#passcode-input"));
+const loginStatus = /** @type {HTMLElement | null} */ (document.querySelector("#login-status"));
+const dashboard = /** @type {HTMLElement | null} */ (document.querySelector("#dashboard"));
+const playerNameEl = /** @type {HTMLElement | null} */ (document.querySelector("#player-name"));
+const arenasContainer = /** @type {HTMLElement | null} */ (document.querySelector("#arenas"));
+const quickMatchBtn = /** @type {HTMLButtonElement | null} */ (document.querySelector("#quick-match"));
+const logoutBtn = /** @type {HTMLButtonElement | null} */ (document.querySelector("#logout-btn"));
+
+let unsubscribe = /** @type {null | (() => void)} */ (null);
+let currentPlayer = getCachedPlayer();
+
+function setStatus(message, type = "info") {
+  if (!loginStatus) return;
+  loginStatus.textContent = message;
+  loginStatus.dataset.type = type;
+}
+
+function showDashboard(show) {
+  if (!dashboard) return;
+  dashboard.hidden = !show;
+  const loginCard = document.querySelector("#login-card");
+  if (loginCard instanceof HTMLElement) {
+    loginCard.hidden = show;
+  }
+}
+
+/**
+ * @param {ArenaSummary[]} arenas
+ */
+function renderArenas(arenas) {
+  if (!arenasContainer) return;
+  arenasContainer.innerHTML = "";
+  if (!arenas.length) {
+    const empty = document.createElement("p");
+    empty.textContent = "No arenas yet. Ask the Boss to make some!";
+    arenasContainer.appendChild(empty);
+    return;
+  }
+
+  arenas.forEach((arena) => {
+    const card = document.createElement("div");
+    card.className = "card";
+    const title = document.createElement("h3");
+    title.textContent = arena.name;
+    card.appendChild(title);
+
+    const status = document.createElement("p");
+    status.textContent = arena.active ? "Active" : "Inactive";
+    card.appendChild(status);
+
+    const occupantsTitle = document.createElement("strong");
+    occupantsTitle.textContent = "Fighters";
+    card.appendChild(occupantsTitle);
+
+    const list = document.createElement("ul");
+    list.style.paddingLeft = "1.25rem";
+    if (arena.presence.length === 0) {
+      const li = document.createElement("li");
+      li.textContent = "(Empty)";
+      list.appendChild(li);
+    } else {
+      arena.presence.forEach((p) => {
+        const li = document.createElement("li");
+        li.textContent = p.playerName;
+        list.appendChild(li);
+      });
+    }
+    card.appendChild(list);
+
+    const joinBtn = document.createElement("button");
+    joinBtn.textContent = "Join";
+    joinBtn.disabled = !arena.active || !currentPlayer;
+    joinBtn.addEventListener("click", async () => {
+      if (!currentPlayer) return;
+      await ensureAnonAuth();
+      await joinArena(arena.id, currentPlayer.playerId, currentPlayer.name);
+      window.location.href = `./arena.html?arena=${encodeURIComponent(arena.id)}`;
+    });
+    card.appendChild(joinBtn);
+
+    arenasContainer.appendChild(card);
+  });
+}
+
+function refreshSubscription() {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+  if (!currentPlayer) return;
+  unsubscribe = listenToArenas((arenas) => {
+    renderArenas(arenas);
+  });
+}
+
+function applyPlayer(player) {
+  currentPlayer = player;
+  if (playerNameEl) {
+    playerNameEl.textContent = player ? player.name : "";
+  }
+  showDashboard(Boolean(player));
+  if (player) {
+    setStatus(`Logged in as ${player.name}`);
+    cachePlayer(player);
+  } else {
+    setStatus("Please enter your passcode to start.");
+    clearCachedPlayer();
+  }
+  refreshSubscription();
+}
+
+if (currentPlayer) {
+  setStatus(`Welcome back, ${currentPlayer.name}!`);
+  applyPlayer(currentPlayer);
+}
+
+if (loginForm) {
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!passcodeInput) return;
+    const passcode = passcodeInput.value.trim();
+    if (!passcode) {
+      setStatus("Please type your passcode.", "error");
+      return;
+    }
+    setStatus("Checking passcode...");
+    try {
+      await ensureAnonAuth();
+      const result = await resolvePasscode(passcode);
+      if (!result) {
+        setStatus("Passcode not found. Try again or ask the Boss.", "error");
+        return;
+      }
+      applyPlayer(result);
+    } catch (err) {
+      console.error(err);
+      setStatus("Something went wrong while logging in.", "error");
+    }
+  });
+}
+
+if (quickMatchBtn) {
+  quickMatchBtn.addEventListener("click", () => {
+    if (!currentPlayer || !arenasContainer) return;
+    const firstJoin = arenasContainer.querySelector("button:not([disabled])");
+    if (firstJoin instanceof HTMLButtonElement) {
+      firstJoin.click();
+    } else {
+      setStatus("No arenas are available yet.", "error");
+    }
+  });
+}
+
+if (logoutBtn) {
+  logoutBtn.addEventListener("click", () => {
+    applyPlayer(null);
+    if (passcodeInput) passcodeInput.value = "";
+  });
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,110 @@
+:root {
+  font-family: "Roboto", Arial, sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+h1,
+ h2,
+ h3 {
+  margin: 0;
+}
+
+form,
+section,
+main {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+}
+
+label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+input,
+button,
+select {
+  font-size: 1.1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 2px solid #cbd5f5;
+  margin-bottom: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+button {
+  cursor: pointer;
+  font-weight: 700;
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+button:hover {
+  background-color: #1d4ed8;
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.card-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #eff6ff;
+  border-radius: 10px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.alert {
+  padding: 1rem;
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 10px;
+}
+
+.notice {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.large-button {
+  font-size: 1.25rem;
+  padding: 1rem 1.5rem;
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,31 @@
+export interface CachedPlayer {
+  playerId: string;
+  name: string;
+}
+
+const STORAGE_KEY = "stickfight:player";
+
+export function getCachedPlayer(): CachedPlayer | null {
+  if (typeof localStorage === "undefined") return null;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as CachedPlayer;
+    if (parsed && parsed.playerId && parsed.name) {
+      return parsed;
+    }
+  } catch (err) {
+    console.warn("Failed to parse cached player", err);
+  }
+  return null;
+}
+
+export function cachePlayer(player: CachedPlayer): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(player));
+}
+
+export function clearCachedPlayer(): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,8 @@
+export const firebaseConfig = {
+  apiKey: "AIzaSyAfqKN-zpIpwblhcafgKEneUnAfcTUV0-A",
+  authDomain: "stickfightpa.firebaseapp.com",
+  projectId: "stickfightpa",
+  storageBucket: "stickfightpa.firebasestorage.app",
+  messagingSenderId: "116175306919",
+  appId: "1:116175306919:web:2e483bbc453498e8f3db82"
+};

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,190 @@
+import {
+  doc,
+  getDoc,
+  setDoc,
+  serverTimestamp,
+  collection,
+  addDoc,
+  getDocs,
+  deleteDoc,
+  onSnapshot,
+  query,
+  orderBy
+} from "firebase/firestore";
+import { db } from "./firebase";
+
+export interface PlayerSummary {
+  id: string;
+  name: string;
+  passcodeId?: string;
+  stats?: Record<string, number>;
+}
+
+export interface ArenaSummary {
+  id: string;
+  name: string;
+  active: boolean;
+  presence: ArenaPresence[];
+}
+
+export interface ArenaPresence {
+  playerId: string;
+  playerName: string;
+  joinedAt?: unknown;
+}
+
+export async function resolvePasscode(passcode: string): Promise<{ playerId: string; name: string } | null> {
+  const ref = doc(db, "passcodes", passcode);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  const { playerId } = snap.data() as { playerId: string };
+  const p = await getDoc(doc(db, "players", playerId));
+  if (!p.exists()) return null;
+  const d = p.data() as { name?: string };
+  return { playerId: p.id, name: d.name ?? "Unknown" };
+}
+
+export async function bossCreatePlayer(name: string, passcode: string): Promise<string> {
+  const pRef = doc(collection(db, "players"));
+  await setDoc(pRef, {
+    name,
+    passcodeId: passcode,
+    stats: { wins: 0, losses: 0, damageDealt: 0, damageTaken: 0 },
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp()
+  });
+  const pcRef = doc(db, "passcodes", passcode);
+  await setDoc(pcRef, { playerId: pRef.id, createdAt: serverTimestamp() });
+  return pRef.id;
+}
+
+export async function bossDeletePlayerById(playerId: string): Promise<void> {
+  const pRef = doc(db, "players", playerId);
+  const pSnap = await getDoc(pRef);
+  if (pSnap.exists()) {
+    const passcodeId = (pSnap.data() as { passcodeId?: string }).passcodeId;
+    if (passcodeId) {
+      await deleteDoc(doc(db, "passcodes", passcodeId));
+    }
+  }
+  await deleteDoc(pRef);
+}
+
+export async function bossCreateArena(name: string): Promise<string> {
+  const aRef = await addDoc(collection(db, "arenas"), {
+    name,
+    active: true,
+    createdAt: serverTimestamp()
+  });
+  return aRef.id;
+}
+
+export async function bossDeleteArena(arenaId: string): Promise<void> {
+  await deleteDoc(doc(db, "arenas", arenaId));
+}
+
+export async function joinArena(arenaId: string, playerId: string, playerName: string): Promise<void> {
+  await setDoc(doc(db, `arenas/${arenaId}/presence/${playerId}`), {
+    playerName,
+    joinedAt: serverTimestamp()
+  });
+}
+
+export async function leaveArena(arenaId: string, playerId: string): Promise<void> {
+  await deleteDoc(doc(db, `arenas/${arenaId}/presence/${playerId}`));
+}
+
+export async function listPlayers(): Promise<PlayerSummary[]> {
+  const snap = await getDocs(collection(db, "players"));
+  return snap.docs.map((d) => {
+    const data = d.data() as { name?: string; passcodeId?: string; stats?: Record<string, number> };
+    return {
+      id: d.id,
+      name: data.name ?? "Unnamed",
+      passcodeId: data.passcodeId,
+      stats: data.stats
+    };
+  });
+}
+
+export async function listArenas(): Promise<ArenaSummary[]> {
+  const arenas = await getDocs(collection(db, "arenas"));
+  const entries = await Promise.all(
+    arenas.docs.map(async (arena) => {
+      const presenceSnap = await getDocs(collection(db, `arenas/${arena.id}/presence`));
+      const presence = presenceSnap.docs.map((p) => {
+        const pdata = p.data() as { playerName?: string; joinedAt?: unknown };
+        return {
+          playerId: p.id,
+          playerName: pdata.playerName ?? "Unknown",
+          joinedAt: pdata.joinedAt
+        };
+      });
+      const data = arena.data() as { name?: string; active?: boolean };
+      return {
+        id: arena.id,
+        name: data.name ?? "Arena",
+        active: data.active ?? false,
+        presence
+      } as ArenaSummary;
+    })
+  );
+  return entries;
+}
+
+export function listenToArenas(callback: (arenas: ArenaSummary[]) => void): () => void {
+  const arenasRef = collection(db, "arenas");
+  return onSnapshot(arenasRef, async (snapshot) => {
+    const arenas = await Promise.all(
+      snapshot.docs.map(async (arena) => {
+        const presenceSnap = await getDocs(collection(db, `arenas/${arena.id}/presence`));
+        const presence = presenceSnap.docs.map((p) => {
+          const pdata = p.data() as { playerName?: string; joinedAt?: unknown };
+          return {
+            playerId: p.id,
+            playerName: pdata.playerName ?? "Unknown",
+            joinedAt: pdata.joinedAt
+          };
+        });
+        const data = arena.data() as { name?: string; active?: boolean };
+        return {
+          id: arena.id,
+          name: data.name ?? "Arena",
+          active: data.active ?? false,
+          presence
+        } as ArenaSummary;
+      })
+    );
+    callback(arenas);
+  });
+}
+
+export async function getArena(arenaId: string): Promise<{ id: string; name: string; active: boolean } | null> {
+  const ref = doc(db, "arenas", arenaId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  const data = snap.data() as { name?: string; active?: boolean };
+  return {
+    id: snap.id,
+    name: data.name ?? "Arena",
+    active: data.active ?? false
+  };
+}
+
+export function listenToArenaPresence(
+  arenaId: string,
+  callback: (presence: ArenaPresence[]) => void
+): () => void {
+  const presenceRef = query(collection(db, `arenas/${arenaId}/presence`), orderBy("joinedAt", "asc"));
+  return onSnapshot(presenceRef, (snapshot) => {
+    const presence = snapshot.docs.map((docSnap) => {
+      const data = docSnap.data() as { playerName?: string; joinedAt?: unknown };
+      return {
+        playerId: docSnap.id,
+        playerName: data.playerName ?? "Unknown",
+        joinedAt: data.joinedAt
+      };
+    });
+    callback(presence);
+  });
+}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,18 @@
+import { initializeApp } from "firebase/app";
+import { getAuth, signInAnonymously, onAuthStateChanged } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+import { firebaseConfig } from "./config";
+
+export const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+export async function ensureAnonAuth(): Promise<void> {
+  if (!auth.currentUser) {
+    await signInAnonymously(auth);
+  }
+}
+
+export function onAuth(cb: (uid: string | null) => void): void {
+  onAuthStateChanged(auth, (u) => cb(u?.uid ?? null));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2020", "DOM"],
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*", "public/**/*", "vite.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + TypeScript project configured for the StickFight Firebase app
- add Firestore helpers for players, passcodes, arenas, and presence management with anonymous auth utilities
- implement minimal public pages for player login, boss admin, and arena occupancy plus permissive dev rules

## Testing
- npm install *(fails: registry access returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cce8a55c94832e920394cf7b5f0383