### PR TITLE
chore: enable react support in vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,15 @@
     "lint": "echo \"(optional) add eslint later\""
   },
   "dependencies": {
-    "firebase": "^10.12.2"
+    "firebase": "^10.12.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.4.5",
     "vite": "^5.2.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "noEmit": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "jsx": "react-jsx"
   },
   "include": ["src", "public", "vite.config.ts"],
   "exclude": ["node_modules"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  server: { port: 5173 },
+  plugins: [react()],
+  server: { host: true, port: 5173, strictPort: true },
   preview: { port: 4173 }
 });


### PR DESCRIPTION
## Summary
- add React runtime dependencies and type packages to package.json
- configure Vite with the React plugin and stricter dev server settings
- enable the React JSX compiler option in the TypeScript config

## Testing
- npm install react react-dom react-router-dom *(fails: npm registry returned 403 Forbidden when fetching firebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cceff5e2b0832ea14c12240f5b95e0