### PR TITLE
Add Phaser training mode prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "firebase": "^10.12.2",
+    "phaser": "^3.80.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0"

--- a/public/training.html
+++ b/public/training.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>StickFight — Training</title>
+    <style>
+      html, body { height:100%; margin:0; background:#0f1115; color:#e6e6e6; font-family:system-ui,Arial; }
+      #hud { position:fixed; top:8px; left:8px; z-index:10; font-size:14px; }
+      a { color:#7dd3fc; }
+      .btn { display:inline-block; padding:6px 10px; background:#1f2937; border:1px solid #374151; border-radius:6px; color:#e5e7eb; text-decoration:none; margin-right:8px; }
+      .btn:hover { background:#374151; }
+    </style>
+  </head>
+  <body>
+    <div id="hud">
+      <a class="btn" href="/index.html">← Lobby</a>
+      <span id="stats"></span>
+    </div>
+    <div id="game"></div>
+    <script type="module" src="/src/game/training.ts"></script>
+  </body>
+</html>

--- a/src/game/attacks/Fireball.ts
+++ b/src/game/attacks/Fireball.ts
@@ -1,0 +1,37 @@
+import Phaser from "phaser";
+
+const FIREBALL_RADIUS = 6;
+
+function ensureCircleTexture(scene: Phaser.Scene, key: string, radius: number) {
+  if (scene.textures.exists(key)) return;
+  const diameter = radius * 2;
+  const graphics = scene.make.graphics({ x: 0, y: 0, add: false });
+  graphics.fillStyle(0xffffff, 1);
+  graphics.fillCircle(radius, radius, radius);
+  graphics.generateTexture(key, diameter, diameter);
+  graphics.destroy();
+}
+
+export class Fireball {
+  sprite: Phaser.Types.Physics.Arcade.ImageWithDynamicBody;
+  alive = true;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, dir: 1 | -1) {
+    ensureCircleTexture(scene, "fireball-circle", FIREBALL_RADIUS);
+    this.sprite = scene.physics.add
+      .image(x, y, "fireball-circle")
+      .setTint(0x60a5fa)
+      .setDepth(1);
+
+    this.sprite.setCircle(FIREBALL_RADIUS).setOffset(-FIREBALL_RADIUS, -FIREBALL_RADIUS);
+    const body = this.sprite.body as Phaser.Physics.Arcade.Body;
+    body.setAllowGravity(false);
+    body.setVelocityX(260 * dir);
+    body.setMaxVelocity(260, 0);
+  }
+
+  destroy() {
+    this.sprite.destroy();
+    this.alive = false;
+  }
+}

--- a/src/game/core/FixedStep.ts
+++ b/src/game/core/FixedStep.ts
@@ -1,0 +1,13 @@
+export class FixedStep {
+  private accumulator = 0;
+
+  constructor(private readonly dt = 1 / 60) {}
+
+  tick(elapsed: number, step: (dt: number) => void) {
+    this.accumulator += elapsed;
+    while (this.accumulator >= this.dt) {
+      step(this.dt);
+      this.accumulator -= this.dt;
+    }
+  }
+}

--- a/src/game/core/HealthBar.ts
+++ b/src/game/core/HealthBar.ts
@@ -1,0 +1,26 @@
+import Phaser from "phaser";
+
+export class HealthBar {
+  private graphics: Phaser.GameObjects.Graphics;
+
+  constructor(
+    private scene: Phaser.Scene,
+    private x: number,
+    private y: number,
+    private width = 240,
+    private height = 14,
+  ) {
+    this.graphics = scene.add.graphics();
+    this.draw(1);
+  }
+
+  draw(ratio: number) {
+    const amount = Phaser.Math.Clamp(ratio, 0, 1);
+    this.graphics.clear();
+    this.graphics.fillStyle(0x222831).fillRect(this.x, this.y, this.width, this.height);
+    this.graphics
+      .fillStyle(0x22c55e)
+      .fillRect(this.x + 1, this.y + 1, (this.width - 2) * amount, this.height - 2);
+    this.graphics.lineStyle(1, 0x111827).strokeRect(this.x, this.y, this.width, this.height);
+  }
+}

--- a/src/game/core/Inputs.ts
+++ b/src/game/core/Inputs.ts
@@ -1,0 +1,33 @@
+export type KeyState = Record<string, boolean>;
+
+export class Inputs {
+  private pressed = new Set<string>();
+  readonly keys: KeyState = {};
+
+  constructor() {
+    window.addEventListener("keydown", (event) => {
+      const key = event.key.toLowerCase();
+      this.keys[key] = true;
+      this.pressed.add(key);
+    });
+
+    window.addEventListener("keyup", (event) => {
+      const key = event.key.toLowerCase();
+      this.keys[key] = false;
+      this.pressed.delete(key);
+    });
+  }
+
+  isDown(key: string) {
+    return !!this.keys[key.toLowerCase()];
+  }
+
+  consumePress(key: string) {
+    const normalized = key.toLowerCase();
+    const wasPressed = this.pressed.has(normalized);
+    if (wasPressed) {
+      this.pressed.delete(normalized);
+    }
+    return wasPressed;
+  }
+}

--- a/src/game/entities/Dummy.ts
+++ b/src/game/entities/Dummy.ts
@@ -1,0 +1,53 @@
+import Phaser from "phaser";
+
+const BODY_RADIUS = 12;
+
+function ensureCircleTexture(scene: Phaser.Scene, key: string, radius: number) {
+  if (scene.textures.exists(key)) return;
+  const diameter = radius * 2;
+  const graphics = scene.make.graphics({ x: 0, y: 0, add: false });
+  graphics.fillStyle(0xffffff, 1);
+  graphics.fillCircle(radius, radius, radius);
+  graphics.generateTexture(key, diameter, diameter);
+  graphics.destroy();
+}
+
+export class Dummy {
+  sprite: Phaser.Types.Physics.Arcade.ImageWithDynamicBody;
+  hp = 100;
+
+  private direction: 1 | -1 = -1;
+  private changeTimer = 0;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, private readonly tint = 0xfacc15) {
+    ensureCircleTexture(scene, "dummy-circle", BODY_RADIUS);
+    this.sprite = scene.physics.add.image(x, y, "dummy-circle").setTint(tint);
+    this.sprite.setCircle(BODY_RADIUS).setOffset(-BODY_RADIUS, -BODY_RADIUS);
+    this.sprite.setCollideWorldBounds(true).setImmovable(false).setMaxVelocity(200, 900);
+  }
+
+  update(dt: number) {
+    const body = this.sprite.body as Phaser.Physics.Arcade.Body;
+    const onGround = body.blocked.down;
+    this.changeTimer -= dt;
+
+    if (onGround && this.changeTimer <= 0) {
+      this.changeTimer = 1.5 + Math.random();
+      this.direction = Math.random() > 0.5 ? 1 : -1;
+    }
+
+    if (onGround) {
+      body.setVelocityX(this.direction * 60);
+    }
+  }
+
+  takeDamage(amount: number) {
+    this.hp = Math.max(0, this.hp - amount);
+    this.sprite.setTintFill(0xffe08a);
+    window.setTimeout(() => this.sprite.setTint(this.tint), 100);
+  }
+
+  healFull() {
+    this.hp = 100;
+  }
+}

--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -1,0 +1,134 @@
+import Phaser from "phaser";
+import { Inputs } from "../core/Inputs";
+
+const BODY_RADIUS = 12;
+const DASH_GAP = 0.25;
+const DASH_DURATION = 0.18;
+const DASH_SPEED = 360;
+
+function ensureCircleTexture(scene: Phaser.Scene, key: string, radius: number) {
+  if (scene.textures.exists(key)) return;
+  const diameter = radius * 2;
+  const graphics = scene.make.graphics({ x: 0, y: 0, add: false });
+  graphics.fillStyle(0xffffff, 1);
+  graphics.fillCircle(radius, radius, radius);
+  graphics.generateTexture(key, diameter, diameter);
+  graphics.destroy();
+}
+
+export class Player {
+  sprite: Phaser.Types.Physics.Arcade.ImageWithDynamicBody;
+  facing: 1 | -1 = 1;
+  hp = 100;
+  invulnTimer = 0;
+  onGround = false;
+  fireCooldown = 0;
+
+  private elapsed = 0;
+  private dashTimer = 0;
+  private lastTapLeft = -Infinity;
+  private lastTapRight = -Infinity;
+
+  constructor(
+    private scene: Phaser.Scene,
+    x: number,
+    y: number,
+    private inputs: Inputs,
+    private readonly tint = 0xffffff,
+  ) {
+    ensureCircleTexture(scene, "player-circle", BODY_RADIUS);
+    this.sprite = scene.physics.add.image(x, y, "player-circle").setTint(this.tint);
+    this.sprite.setCircle(BODY_RADIUS).setOffset(-BODY_RADIUS, -BODY_RADIUS);
+    this.sprite
+      .setBounce(0)
+      .setDrag(1200, 0)
+      .setFriction(0, 0)
+      .setCollideWorldBounds(true)
+      .setMaxVelocity(320, 900);
+  }
+
+  update(dt: number) {
+    const body = this.sprite.body as Phaser.Physics.Arcade.Body;
+    this.elapsed += dt;
+    this.onGround = body.blocked.down;
+
+    const leftDown = this.inputs.isDown("arrowleft") || this.inputs.isDown("a");
+    const rightDown = this.inputs.isDown("arrowright") || this.inputs.isDown("d");
+
+    const leftPressed =
+      this.inputs.consumePress("arrowleft") || this.inputs.consumePress("a");
+    const rightPressed =
+      this.inputs.consumePress("arrowright") || this.inputs.consumePress("d");
+
+    if (leftDown && !rightDown) {
+      this.facing = -1;
+    } else if (rightDown && !leftDown) {
+      this.facing = 1;
+    }
+
+    if (this.onGround) {
+      if (leftPressed) {
+        this.handleDash(-1, body);
+      }
+      if (rightPressed) {
+        this.handleDash(1, body);
+      }
+    }
+
+    const walkSpeed = 180;
+    let vx = 0;
+    if (leftDown && !rightDown) {
+      vx = -walkSpeed;
+    } else if (rightDown && !leftDown) {
+      vx = walkSpeed;
+    }
+
+    if (this.dashTimer > 0) {
+      this.dashTimer = Math.max(0, this.dashTimer - dt);
+      body.setVelocityX(this.facing * DASH_SPEED);
+    } else {
+      body.setVelocityX(vx);
+    }
+
+    const wantJump = this.inputs.isDown("arrowup") || this.inputs.isDown("w");
+    if (wantJump && this.onGround) {
+      body.setVelocityY(-360);
+    }
+
+    this.fireCooldown = Math.max(0, this.fireCooldown - dt);
+    this.invulnTimer = Math.max(0, this.invulnTimer - dt);
+  }
+
+  private handleDash(direction: 1 | -1, body: Phaser.Physics.Arcade.Body) {
+    const now = this.elapsed;
+    if (direction === -1) {
+      if (now - this.lastTapLeft <= DASH_GAP) {
+        this.triggerDash(direction, body);
+      }
+      this.lastTapLeft = now;
+    } else {
+      if (now - this.lastTapRight <= DASH_GAP) {
+        this.triggerDash(direction, body);
+      }
+      this.lastTapRight = now;
+    }
+  }
+
+  private triggerDash(direction: 1 | -1, body: Phaser.Physics.Arcade.Body) {
+    this.facing = direction;
+    this.dashTimer = DASH_DURATION;
+    body.setVelocity(direction * DASH_SPEED, body.velocity.y);
+  }
+
+  takeDamage(amount: number) {
+    if (this.invulnTimer > 0) return;
+    this.hp = Math.max(0, this.hp - amount);
+    this.invulnTimer = 0.3;
+    this.sprite.setTintFill(0xfff1f2);
+    window.setTimeout(() => this.sprite.setTint(this.tint), 120);
+  }
+
+  healFull() {
+    this.hp = 100;
+  }
+}

--- a/src/game/training.ts
+++ b/src/game/training.ts
@@ -1,0 +1,249 @@
+import Phaser from "phaser";
+import { Fireball } from "./attacks/Fireball";
+import { FixedStep } from "./core/FixedStep";
+import { HealthBar } from "./core/HealthBar";
+import { Inputs } from "./core/Inputs";
+import { Dummy } from "./entities/Dummy";
+import { Player } from "./entities/Player";
+
+interface TrainingStats {
+  wins: number;
+  losses: number;
+}
+
+class TrainingScene extends Phaser.Scene {
+  inputs!: Inputs;
+  player!: Player;
+  dummy!: Dummy;
+
+  private fixed = new FixedStep(1 / 60);
+  private playerBar!: HealthBar;
+  private dummyBar!: HealthBar;
+  private stats: TrainingStats = { wins: 0, losses: 0 };
+  private statsElement?: HTMLElement | null;
+  private fireballs: Fireball[] = [];
+  private fireballGroup!: Phaser.Physics.Arcade.Group;
+  private flyKickTimer = 0;
+  private bicycleTimer = 0;
+
+  constructor() {
+    super("Training");
+  }
+
+  preload() {
+    /* no external assets */
+  }
+
+  create() {
+    this.inputs = new Inputs();
+    this.cameras.main.setBackgroundColor(0x0f1115);
+    this.physics.world.setBounds(0, 0, 960, 540);
+
+    const ground = this.add.rectangle(480, 500, 920, 12, 0x111827);
+    this.physics.add.existing(ground, true);
+
+    const midLine = this.add.rectangle(480, 320, 4, 360, 0x111827, 0.4);
+    midLine.setDepth(-1);
+
+    this.player = new Player(this, 220, 460, this.inputs, 0x86efac);
+    this.dummy = new Dummy(this, 720, 460, 0xfacc15);
+
+    this.physics.add.collider(this.player.sprite, ground as Phaser.GameObjects.GameObject);
+    this.physics.add.collider(this.dummy.sprite, ground as Phaser.GameObjects.GameObject);
+    this.physics.add.collider(this.player.sprite, this.dummy.sprite);
+
+    this.playerBar = new HealthBar(this, 20, 20);
+    this.dummyBar = new HealthBar(this, 700, 20);
+
+    this.fireballGroup = this.physics.add.group();
+    this.physics.add.overlap(
+      this.fireballGroup,
+      this.dummy.sprite,
+      (fireballObj) => {
+        const projectile = this.fireballs.find((fb) => fb.sprite === fireballObj);
+        if (!projectile) return;
+        this.dummy.takeDamage(10);
+        this.disposeFireball(projectile);
+      },
+      undefined,
+      this,
+    );
+
+    this.statsElement = document.getElementById("stats");
+  }
+
+  update(_time: number, delta: number) {
+    this.fixed.tick(delta / 1000, (dt) => {
+      this.player.update(dt);
+      this.dummy.update(dt);
+      this.handleAttacks();
+      this.handleSpecials(dt);
+      this.cleanupProjectiles();
+    });
+
+    if (this.dummy.hp <= 0) {
+      this.stats.wins += 1;
+      this.respawn(this.dummy, 720, 460);
+    }
+
+    if (this.player.hp <= 0) {
+      this.stats.losses += 1;
+      this.respawn(this.player, 220, 460);
+    }
+
+    this.playerBar.draw(this.player.hp / 100);
+    this.dummyBar.draw(this.dummy.hp / 100);
+
+    if (this.statsElement) {
+      this.statsElement.textContent =
+        `Wins: ${this.stats.wins}  Losses: ${this.stats.losses}  ` +
+        `Controls: ←/→ move, ↑ jump, ⇧ (double-tap) dash, J light, K heavy, L fireball, ` +
+        `(air) ↓+J fly kick, (air) K bicycle kick`;
+    }
+  }
+
+  private handleAttacks() {
+    if (this.inputs.consumePress("j")) {
+      this.lightAttack();
+    }
+
+    if (this.inputs.consumePress("k")) {
+      this.heavyAttack();
+    }
+
+    if (this.inputs.consumePress("l")) {
+      this.fireball();
+    }
+  }
+
+  private handleSpecials(dt: number) {
+    this.flyKickTimer = Math.max(0, this.flyKickTimer - dt);
+    this.bicycleTimer = Math.max(0, this.bicycleTimer - dt);
+
+    const downHeld = this.inputs.isDown("arrowdown") || this.inputs.isDown("s");
+
+    if (!this.player.onGround && downHeld && this.inputs.isDown("j")) {
+      const body = this.player.sprite.body as Phaser.Physics.Arcade.Body;
+      if (this.flyKickTimer <= 0) {
+        body.setVelocity(body.velocity.x + 120 * this.player.facing, 320);
+        this.flyKickTimer = 0.15;
+      }
+    }
+
+    if (!this.player.onGround && this.inputs.isDown("k")) {
+      const body = this.player.sprite.body as Phaser.Physics.Arcade.Body;
+      body.setVelocityY(Math.min(body.velocity.y, -40));
+      if (this.bicycleTimer <= 0) {
+        const aura = new Phaser.Geom.Circle(this.player.sprite.x, this.player.sprite.y, 24);
+        const hit = Phaser.Geom.Intersects.CircleToRectangle(aura, this.dummy.sprite.getBounds());
+        if (hit) {
+          this.dummy.takeDamage(2);
+        }
+        const graphics = this.add.graphics();
+        graphics.lineStyle(2, 0xa78bfa).strokeCircleShape(aura);
+        this.time.delayedCall(60, () => graphics.destroy());
+        this.bicycleTimer = 0.08;
+      }
+    }
+  }
+
+  private lightAttack() {
+    const sprite = this.player.sprite;
+    const dx = this.player.facing === 1 ? 28 : -50;
+    const box = new Phaser.Geom.Rectangle(sprite.x + dx, sprite.y - 14, 44, 28);
+    const hit = Phaser.Geom.Rectangle.Overlaps(box, this.dummy.sprite.getBounds());
+    if (hit) {
+      this.dummy.takeDamage(5);
+      const body = this.dummy.sprite.body as Phaser.Physics.Arcade.Body;
+      body.setVelocity(120 * this.player.facing, -100);
+    }
+    this.drawBox(box, 0x34d399, 90);
+  }
+
+  private heavyAttack() {
+    const sprite = this.player.sprite;
+    const dx = this.player.facing === 1 ? 36 : -62;
+    const box = new Phaser.Geom.Rectangle(sprite.x + dx, sprite.y - 20, 58, 40);
+    const hit = Phaser.Geom.Rectangle.Overlaps(box, this.dummy.sprite.getBounds());
+    if (hit) {
+      this.dummy.takeDamage(15);
+      const body = this.dummy.sprite.body as Phaser.Physics.Arcade.Body;
+      body.setVelocity(220 * this.player.facing, -220);
+    }
+    this.drawBox(box, 0xf472b6, 120);
+  }
+
+  private fireball() {
+    if (this.player.fireCooldown > 0) return;
+    const sprite = this.player.sprite;
+    const fireball = new Fireball(this, sprite.x + 18 * this.player.facing, sprite.y - 4, this.player.facing);
+    this.fireballs.push(fireball);
+    this.fireballGroup.add(fireball.sprite);
+    this.player.fireCooldown = 0.45;
+    this.time.delayedCall(2000, () => this.disposeFireball(fireball));
+  }
+
+  private drawBox(rect: Phaser.Geom.Rectangle, color: number, duration: number) {
+    const graphics = this.add.graphics();
+    graphics.lineStyle(2, color).strokeRectShape(rect);
+    this.time.delayedCall(duration, () => graphics.destroy());
+  }
+
+  private cleanupProjectiles() {
+    for (const projectile of [...this.fireballs]) {
+      if (!projectile.alive) {
+        this.disposeFireball(projectile);
+        continue;
+      }
+
+      if (projectile.sprite.x < -40 || projectile.sprite.x > 1000) {
+        this.disposeFireball(projectile);
+      }
+    }
+  }
+
+  private disposeFireball(projectile: Fireball) {
+    if (!projectile.alive) {
+      this.removeFireball(projectile);
+      return;
+    }
+
+    projectile.destroy();
+    this.removeFireball(projectile);
+  }
+
+  private removeFireball(projectile: Fireball) {
+    this.fireballs = this.fireballs.filter((fb) => fb !== projectile);
+    if (this.fireballGroup.contains(projectile.sprite)) {
+      this.fireballGroup.remove(projectile.sprite, false, false);
+    }
+  }
+
+  private respawn(entity: Player | Dummy, x: number, y: number) {
+    entity.healFull();
+    entity.sprite.setPosition(x, y);
+    const body = entity.sprite.body as Phaser.Physics.Arcade.Body;
+    body.setVelocity(0, 0);
+  }
+}
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  parent: "game",
+  width: 960,
+  height: 540,
+  backgroundColor: "#0f1115",
+  physics: {
+    default: "arcade",
+    arcade: {
+      gravity: { y: 800 },
+      debug: false,
+    },
+  },
+  scene: [TrainingScene],
+};
+
+const game = new Phaser.Game(config);
+(window as any).game = game;
+
+export {};


### PR DESCRIPTION
## Summary
- add Phaser 3 as a dependency and expose a new `/training.html` entry point for the local sandbox
- implement a Phaser training scene with player controls, dummy opponent behaviour, attacks, specials, HUD, and respawn logic
- add supporting gameplay utilities for fixed-step updates, inputs, health bars, projectiles, and simple AI entities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccf9b579e0832ea432e0204c069b84