### PR TITLE
Add /training route (Phaser)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 import { AdminPage } from "./pages/AdminPage";
 import { HomePage } from "./pages/HomePage";
 import { ArenaPage } from "./pages/ArenaPage";
+import TrainingPage from "./pages/TrainingPage";
 import { AuthProvider } from "./context/AuthContext";
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/arena/:arenaId" element={<ArenaPage />} />
+        <Route path="/training" element={<TrainingPage />} />
       </Routes>
     </AuthProvider>
   );

--- a/src/pages/TrainingPage.tsx
+++ b/src/pages/TrainingPage.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from "react";
+import Phaser from "phaser";
+
+const TrainingPage: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || gameRef.current) return;
+
+    class TrainingScene extends Phaser.Scene {
+      constructor() {
+        super("Training");
+      }
+      create() {
+        console.info("[training] scene.create()");
+        this.cameras.main.setBackgroundColor(0x0f1115);
+        this.add
+          .text(480, 60, "Training Scene Ready", {
+            fontFamily: "system-ui, Arial",
+            fontSize: "24px",
+            color: "#e6e6e6",
+          })
+          .setOrigin(0.5, 0.5);
+
+        const g = this.add.graphics();
+        g.fillStyle(0x86efac).fillCircle(480, 270, 12);
+      }
+    }
+
+    const config: Phaser.Types.Core.GameConfig = {
+      type: Phaser.AUTO,
+      width: 960,
+      height: 540,
+      parent: containerRef.current,
+      backgroundColor: "#0f1115",
+      scene: [TrainingScene],
+    };
+
+    gameRef.current = new Phaser.Game(config);
+
+    return () => {
+      if (gameRef.current) {
+        gameRef.current.destroy(true);
+        gameRef.current = null;
+      }
+    };
+  }, []);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <div style={{ marginBottom: 12 }}>
+        <a
+          href="/"
+          style={{
+            padding: "6px 10px",
+            background: "#1f2937",
+            border: "1px solid #374151",
+            borderRadius: 6,
+            color: "#e5e7eb",
+            textDecoration: "none",
+          }}
+        >
+          ← Lobby
+        </a>
+      </div>
+      <div ref={containerRef} />
+    </div>
+  );
+};
+
+export default TrainingPage;


### PR DESCRIPTION
## Summary
- add a TrainingPage React component that mounts a minimal Phaser scene
- wire the new page into the router so it is available at /training with existing routes unaffected

## Testing
- `npm install` *(fails: registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd02339380832ebe9a475dce8e96d5