### PR TITLE
Fix Firebase helper exports and improve dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Minimal Firebase + Vite TypeScript scaffold with:
 - Anonymous Auth
 - Firestore data model (players, passcodes, arenas, presence)
-- Basic pages: `/index.html` (passcode login + arena list), `/admin.html` (boss), `/arena.html` (presence + exit)
+- Basic pages: `/` (lobby), `/admin` (boss tools), `/arena/:id` (presence + exit), `/training` (Phaser test scene)
 
 ## Prereqs
 - Firebase project: **stickfightpa**
@@ -14,3 +14,23 @@ Minimal Firebase + Vite TypeScript scaffold with:
 ```bash
 npm install
 npm run dev
+```
+
+The dev server binds to `0.0.0.0` so it works in Codespaces and remote containers. Visit `http://localhost:5173/` (or the forwarded port) and navigate to `/training` for the Phaser training route. Legacy links to `/training.html` will redirect automatically.
+
+To clean Vite's cache, run `npm run clean:vite`.
+
+## Quick sanity check (in browser console)
+
+After loading the app locally, you can confirm Firebase connectivity by pasting this snippet into the browser console:
+
+```js
+(async () => {
+  const { ensureAnonAuth, listArenas } = await import("/src/firebase.ts");
+  const user = await ensureAnonAuth();
+  console.log("Anon UID", user.uid);
+  console.log("Arenas", await listArenas());
+})();
+```
+
+It signs in anonymously (if needed) and fetches the arenas collection, logging the results.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
+    "clean:vite": "rimraf node_modules/.vite || rm -rf node_modules/.vite || true",
     "lint": "echo \"(optional) add eslint later\""
   },
   "dependencies": {
@@ -20,6 +21,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "rimraf": "^5.0.7",
     "typescript": "^5.4.5",
     "vite": "^5.2.0"
   }


### PR DESCRIPTION
## Summary
- replace `src/firebase.ts` with the full helper surface required by the React pages
- bind the dev server to 0.0.0.0 and document the Codespaces-friendly workflow plus sanity check snippet
- add a Vite cache cleaning script and refresh the README with updated route info

## Testing
- npm run build *(fails: missing @vitejs/plugin-react in the offline test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd04b490e0832e984d87fd94e270df