### PR TITLE
Add standalone training page

### DIFF
--- a/public/training.html
+++ b/public/training.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>StickFight — Training</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      html, body { height:100%; margin:0; background:#0f1115; color:#e6e6e6; font-family:system-ui, Arial; }
+      #hud { position:fixed; top:8px; left:8px; z-index:10; font-size:14px; }
+      a { color:#7dd3fc; text-decoration:none; }
+      .btn { display:inline-block; padding:6px 10px; background:#1f2937; border:1px solid #374151; border-radius:6px; color:#e5e7eb; margin-right:8px; }
+      .btn:hover { background:#374151; }
+      #game { outline:1px solid #333; min-height:540px; }
+    </style>
+  </head>
+  <body>
+    <div id="hud">
+      <a class="btn" href="/index.html">← Lobby</a>
+      <span id="stats"></span>
+    </div>
+    <div id="game"></div>
+
+    <!-- Load Phaser UMD from CDN so we don't rely on Vite modules -->
+    <script src="https://unpkg.com/phaser@3/dist/phaser.js"></script>
+    <!-- Our standalone script (no imports) -->
+    <script src="/public/training.js"></script>
+  </body>
+</html>

--- a/public/training.js
+++ b/public/training.js
@@ -1,0 +1,41 @@
+// Plain JS (no imports). Uses window.Phaser from the CDN build.
+(function () {
+  console.info("[training] script loaded");
+
+  var TrainingScene = new Phaser.Class({
+    Extends: Phaser.Scene,
+    initialize: function TrainingScene() { Phaser.Scene.call(this, { key: "Training" }); },
+    create: function () {
+      console.info("[training] scene.create()");
+      this.cameras.main.setBackgroundColor(0x0f1115);
+      this.add.text(480, 60, "Training Scene Ready", {
+        fontFamily: "system-ui, Arial",
+        fontSize: "24px",
+        color: "#e6e6e6"
+      }).setOrigin(0.5, 0.5);
+
+      // Draw a simple dot so we always see something
+      var g = this.add.graphics();
+      g.fillStyle(0x86efac).fillCircle(480, 270, 12);
+    }
+  });
+
+  var config = {
+    type: Phaser.AUTO,
+    width: 960,
+    height: 540,
+    parent: "game",
+    backgroundColor: "#0f1115",
+    scene: [TrainingScene]
+  };
+
+  // Guard if Phaser failed to load
+  if (!window.Phaser) {
+    var el = document.getElementById("stats");
+    if (el) el.textContent = "Failed to load Phaser. Check network.";
+    console.error("[training] Phaser not found on window.");
+    return;
+  }
+
+  new Phaser.Game(config);
+})();


### PR DESCRIPTION
## Summary
- add a standalone training.html served from the public directory that loads Phaser from CDN
- create a matching training.js script that instantiates a basic Phaser scene without module imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd0eecf6e0832ea3eef8127d369efd