### PR TITLE
Fix training page asset loading

### DIFF
--- a/public/training.html
+++ b/public/training.html
@@ -20,9 +20,12 @@
     </div>
     <div id="game"></div>
 
-    <!-- Load Phaser UMD from CDN so we don't rely on Vite modules -->
+    <script>
+      console.info("[training.html] page loaded");
+    </script>
+    <!-- Phaser UMD from CDN -->
     <script src="https://unpkg.com/phaser@3/dist/phaser.js"></script>
-    <!-- Our standalone script (no imports) -->
-    <script src="/public/training.js"></script>
+    <!-- IMPORTANT: public assets are served from root; do NOT prefix with /public -->
+    <script src="/training.js"></script>
   </body>
 </html>

--- a/public/training.js
+++ b/public/training.js
@@ -1,20 +1,24 @@
-// Plain JS (no imports). Uses window.Phaser from the CDN build.
 (function () {
-  console.info("[training] script loaded");
+  console.info("[training.js] script loaded");
+
+  if (!window.Phaser) {
+    const el = document.getElementById("stats");
+    if (el) el.textContent = "Failed to load Phaser (window.Phaser missing).";
+    console.error("[training.js] Phaser not found on window.");
+    return;
+  }
 
   var TrainingScene = new Phaser.Class({
     Extends: Phaser.Scene,
     initialize: function TrainingScene() { Phaser.Scene.call(this, { key: "Training" }); },
     create: function () {
-      console.info("[training] scene.create()");
+      console.info("[training.js] scene.create()");
       this.cameras.main.setBackgroundColor(0x0f1115);
       this.add.text(480, 60, "Training Scene Ready", {
         fontFamily: "system-ui, Arial",
         fontSize: "24px",
         color: "#e6e6e6"
       }).setOrigin(0.5, 0.5);
-
-      // Draw a simple dot so we always see something
       var g = this.add.graphics();
       g.fillStyle(0x86efac).fillCircle(480, 270, 12);
     }
@@ -28,14 +32,6 @@
     backgroundColor: "#0f1115",
     scene: [TrainingScene]
   };
-
-  // Guard if Phaser failed to load
-  if (!window.Phaser) {
-    var el = document.getElementById("stats");
-    if (el) el.textContent = "Failed to load Phaser. Check network.";
-    console.error("[training] Phaser not found on window.");
-    return;
-  }
 
   new Phaser.Game(config);
 })();


### PR DESCRIPTION
## Summary
- update training.html to load training.js from the public root and add console breadcrumbs
- enhance training.js with Phaser fallback messaging and scene logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd103c534c832ea1dd1e51eca6a2b2