### PR TITLE
Switch Vite to MPA with standalone training page

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StickFight — Admin</title>
+  </head>
+  <body style="margin:0">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/mpa-verify.html
+++ b/public/mpa-verify.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <meta charset="utf-8" />
+  <title>MPA VERIFY</title>
+  <body>
+    <h1>MPA VERIFY — If you see this, Vite is serving raw HTML (no SPA)</h1>
+  </body>
+</html>

--- a/public/training-standalone.html
+++ b/public/training-standalone.html
@@ -1,8 +1,19 @@
 <!doctype html>
 <html>
-  <meta charset="utf-8">
-  <title>STATIC TEST — training-standalone.html</title>
-  <body>
-    <h1>STATIC TEST — If you see this, the SPA did NOT intercept.</h1>
+  <head>
+    <meta charset="utf-8" />
+    <title>StickFight — Training (Standalone)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body style="margin:0;background:#0f1115;color:#e6e6e6;font-family:system-ui,Arial">
+    <div style="position:fixed;top:8px;left:8px;z-index:10">
+      <a href="/index.html" style="padding:6px 10px;background:#1f2937;border:1px solid #374151;border-radius:6px;color:#e5e7eb;text-decoration:none">← Lobby</a>
+      <span id="stats"></span>
+    </div>
+    <div id="game" style="outline:1px solid #333;min-height:540px"></div>
+
+    <script>console.info("[training-standalone] HTML loaded");</script>
+    <script src="https://unpkg.com/phaser@3/dist/phaser.js"></script>
+    <script src="/training-standalone.js"></script>
   </body>
 </html>

--- a/public/training-standalone.js
+++ b/public/training-standalone.js
@@ -3,10 +3,8 @@
   if (!window.Phaser) {
     const el = document.getElementById("stats");
     if (el) el.textContent = "Failed to load Phaser (window.Phaser missing).";
-    console.error("[training-standalone.js] Phaser not found on window.");
     return;
   }
-
   var TrainingScene = new Phaser.Class({
     Extends: Phaser.Scene,
     initialize: function TrainingScene() { Phaser.Scene.call(this, { key: "Training" }); },
@@ -22,13 +20,5 @@
       g.fillStyle(0x86efac).fillCircle(480, 270, 12);
     }
   });
-
-  new Phaser.Game({
-    type: Phaser.AUTO,
-    width: 960,
-    height: 540,
-    parent: "game",
-    backgroundColor: "#0f1115",
-    scene: [TrainingScene]
-  });
+  new Phaser.Game({ type: Phaser.AUTO, width: 960, height: 540, parent: "game", backgroundColor: "#0f1115", scene: [TrainingScene] });
 })();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
 export default defineConfig({
   plugins: [react()],
   server: { host: true, port: 5173, strictPort: true },
   preview: { port: 4173 },
-  appType: "mpa"   // ← IMPORTANT: serve .html files as-is; disable SPA fallback
+  appType: "mpa",
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        admin: resolve(__dirname, "public/admin.html"),
+        trainingStandalone: resolve(__dirname, "public/training-standalone.html"),
+        mpaVerify: resolve(__dirname, "public/mpa-verify.html"),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite to run as an MPA with explicit HTML entry points
- add admin, mpa verification, and standalone training HTML assets served as raw pages
- create a standalone training script that bootstraps Phaser from the CDN

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd98d9a094832eac7972449bd263bb