### PR TITLE
Add temporary firebase dev stub

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,229 +1,154 @@
-import { initializeApp } from "firebase/app";
-import {
-  getAuth,
-  onAuthStateChanged,
-  signInAnonymously,
-  connectAuthEmulator,
-  type User,
-} from "firebase/auth";
-import {
-  getFirestore,
-  connectFirestoreEmulator,
-  doc,
-  getDoc,
-  setDoc,
-  updateDoc,
-  addDoc,
-  getDocs,
-  collection,
-  serverTimestamp,
-  query,
-  where,
-} from "firebase/firestore";
+//
+// 🚨 TEMP DEV STUB: This file is a minimal no-backend, in-memory implementation
+// that exports ALL the names the app imports so Vite can start.
+// Use only for local dev to get /training working. Replace with real Firebase
+// implementation once your exports mismatch is resolved.
+//
 
+import type { Auth, User as FirebaseUser } from "firebase/auth";
+import type { Firestore } from "firebase/firestore";
+import type { Arena, BossProfile, LeaderboardEntry, PlayerProfile } from "./types/models";
+
+// Pretend config (kept just to satisfy imports elsewhere if inspected)
 export const firebaseConfig = {
-  apiKey: "AIzaSyAfqKN-zpIpwblhcafgKEneUnAfcTUV0-A",
-  authDomain: "stickfightpa.firebaseapp.com",
-  projectId: "stickfightpa",
-  storageBucket: "stickfightpa.firebasestorage.app",
-  messagingSenderId: "116175306919",
-  appId: "1:116175306919:web:2e483bbc453498e8f3db82",
+  apiKey: "dev-stub",
+  authDomain: "dev-stub",
+  projectId: "dev-stub",
+  storageBucket: "dev-stub",
+  messagingSenderId: "dev-stub",
+  appId: "dev-stub",
 };
 
-export const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+// Minimal "singletons"
+const fakeUser = { uid: "dev-anon" } as unknown as FirebaseUser;
+export const app = { name: "dev-stub-app" } as const;
+export const auth = { currentUser: fakeUser } as unknown as Auth;
+export const db = { name: "dev-stub-db" } as unknown as Firestore;
 
-// Dev emulator hook (no-op unless explicitly enabled)
+// Flags
+export const USING_DEV_STUB = true;
+
+// No-op emulator hook
 export const maybeConnectEmulators = () => {
-  if (import.meta.env?.DEV && import.meta.env?.VITE_USE_FIREBASE_EMULATORS === "true") {
-    try {
-      connectAuthEmulator(auth, "http://127.0.0.1:9099");
-      connectFirestoreEmulator(db, "127.0.0.1", 8080);
-      console.info("[firebase] emulators connected");
-    } catch (e) {
-      console.warn("[firebase] emulator connect skipped:", e);
-    }
-  }
+  console.info("[firebase DEV STUB] maybeConnectEmulators()");
 };
 
+// Auth helpers
+export type User = FirebaseUser;
 export async function ensureAnonAuth(): Promise<User> {
-  if (!auth.currentUser) {
-    const cred = await signInAnonymously(auth);
-    return cred.user;
-  }
-  return auth.currentUser!;
+  return fakeUser;
 }
 export function onAuth(cb: (uid: string | null) => void): void {
-  onAuthStateChanged(auth, (u) => cb(u?.uid ?? null));
+  // Immediately call back with a fake user
+  queueMicrotask(() => cb(fakeUser.uid));
 }
 export const signInAnonymouslyWithTracking = async (): Promise<User> => {
-  const cred = await signInAnonymously(auth);
-  return cred.user;
+  return fakeUser;
 };
 
-type ISODate = string;
-export interface BossProfile { id: string; displayName: string; createdAt: ISODate; }
-export interface PlayerProfile {
-  id: string;
-  codename: string;
-  passcode?: string;
-  preferredArenaId?: string;
-  createdAt: ISODate;
-  lastActiveAt?: ISODate;
-}
-export interface Arena {
-  id: string;
-  name: string;
-  description?: string;
-  capacity?: number | null;
-  isActive: boolean;
-  createdAt: ISODate;
-}
-export interface LeaderboardEntry {
-  id: string;
-  playerId: string;
-  playerCodename?: string;
-  wins: number;
-  losses: number;
-  streak: number;
-  updatedAt: ISODate;
-}
+// In-memory stores (dev only)
+const memory = {
+  boss: { id: "primary", displayName: "Boss", createdAt: new Date().toISOString() } as BossProfile,
+  players: new Map<string, PlayerProfile>(),
+  passcodes: new Map<string, string>(), // passcode -> playerId
+  arenas: new Map<string, Arena>(),
+  leaderboard: new Map<string, LeaderboardEntry>(),
+};
 
-// Boss profile
+// Boss
 export const ensureBossProfile = async (displayName: string) => {
-  const ref = doc(db, "boss", "primary");
-  const snap = await getDoc(ref);
-  if (!snap.exists()) {
-    const profile: BossProfile = { id: "primary", displayName, createdAt: new Date().toISOString() };
-    await setDoc(ref, profile);
-  }
-  const again = await getDoc(ref);
-  return again.data() as BossProfile | undefined;
+  memory.boss.displayName = displayName || memory.boss.displayName;
+  return memory.boss;
 };
 
 // Players & passcodes
-export interface CreatePlayerInput { codename: string; passcode: string; preferredArenaId?: string; }
+export interface CreatePlayerInput {
+  codename: string;
+  passcode: string;
+  preferredArenaId?: string;
+}
 
 export const createPlayer = async (input: CreatePlayerInput) => {
-  const now = serverTimestamp();
-  const pRef = await addDoc(collection(db, "players"), {
+  const id = "dev-player-" + Math.random().toString(36).slice(2, 9);
+  const createdAt = new Date().toISOString();
+  const p: PlayerProfile = {
+    id,
     codename: input.codename,
     passcode: input.passcode,
-    preferredArenaId: input.preferredArenaId ?? null,
-    createdAt: now,
-  });
-  await setDoc(doc(db, "passcodes", input.passcode), { playerId: pRef.id, createdAt: now });
-  return pRef.id;
+    preferredArenaId: input.preferredArenaId,
+    createdAt,
+  };
+  memory.players.set(id, p);
+  memory.passcodes.set(input.passcode, id);
+  return id;
 };
 
 export const findPlayerByPasscode = async (passcode: string) => {
-  const mapSnap = await getDoc(doc(db, "passcodes", passcode));
-  if (mapSnap.exists()) {
-    const playerId = (mapSnap.data() as any).playerId as string;
-    const p = await getDoc(doc(db, "players", playerId));
-    if (p.exists()) {
-      const d = p.data() as any;
-      const createdAt = d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString();
-      const lastActiveAt = d.lastActiveAt?.toDate?.().toISOString?.();
-      return { id: p.id, codename: d.codename, preferredArenaId: d.preferredArenaId ?? undefined, createdAt, lastActiveAt } as PlayerProfile;
-    }
-  }
-  const qy = query(collection(db, "players"), where("passcode", "==", passcode));
-  const res = await getDocs(qy);
-  if (!res.empty) {
-    const s = res.docs[0];
-    const d = s.data() as any;
-    const createdAt = d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString();
-    const lastActiveAt = d.lastActiveAt?.toDate?.().toISOString?.();
-    return { id: s.id, codename: d.codename, preferredArenaId: d.preferredArenaId ?? undefined, createdAt, lastActiveAt } as PlayerProfile;
-  }
-  return undefined;
+  const id = memory.passcodes.get(passcode);
+  if (!id) return undefined;
+  return memory.players.get(id);
 };
 
 export const updatePlayerActivity = async (playerId: string) => {
-  await updateDoc(doc(db, "players", playerId), { lastActiveAt: serverTimestamp() });
+  const p = memory.players.get(playerId);
+  if (p) p.lastActiveAt = new Date().toISOString();
 };
 
 // Arenas
-export interface CreateArenaInput { name: string; description?: string; capacity?: number; }
+export interface CreateArenaInput {
+  name: string;
+  description?: string;
+  capacity?: number;
+}
 
 export const createArena = async (input: CreateArenaInput) => {
-  const now = serverTimestamp();
-  const aRef = await addDoc(collection(db, "arenas"), {
+  const id = "dev-arena-" + Math.random().toString(36).slice(2, 9);
+  const a: Arena = {
+    id,
     name: input.name,
     description: input.description ?? "",
-    capacity: input.capacity ?? null,
+    capacity: input.capacity,
     isActive: true,
-    createdAt: now,
-  });
-  return aRef.id;
+    createdAt: new Date().toISOString(),
+  };
+  memory.arenas.set(id, a);
+  return id;
 };
 
 export const listArenas = async (): Promise<Arena[]> => {
-  const snap = await getDocs(collection(db, "arenas"));
-  return snap.docs.map((s) => {
-    const d = s.data() as any;
-    const createdAt = d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString();
-    return {
-      id: s.id,
-      name: d.name,
-      description: d.description ?? undefined,
-      capacity: d.capacity ?? undefined,
-      isActive: !!d.isActive,
-      createdAt,
-    } as Arena;
-  });
+  return Array.from(memory.arenas.values());
 };
 
 // Leaderboard
-export interface UpsertLeaderboardInput { playerId: string; wins?: number; losses?: number; streak?: number; }
+export interface UpsertLeaderboardInput {
+  playerId: string;
+  wins?: number;
+  losses?: number;
+  streak?: number;
+}
 
 export const upsertLeaderboardEntry = async (input: UpsertLeaderboardInput) => {
-  const ref = doc(db, "leaderboard", input.playerId);
-  const snap = await getDoc(ref);
-  const now = serverTimestamp();
-  if (!snap.exists()) {
-    await setDoc(ref, {
+  const cur = memory.leaderboard.get(input.playerId);
+  if (!cur) {
+    memory.leaderboard.set(input.playerId, {
+      id: input.playerId,
       playerId: input.playerId,
       wins: input.wins ?? 0,
       losses: input.losses ?? 0,
       streak: input.streak ?? 0,
-      updatedAt: now,
+      updatedAt: new Date().toISOString(),
     });
-    return;
+  } else {
+    cur.wins = input.wins ?? cur.wins;
+    cur.losses = input.losses ?? cur.losses;
+    cur.streak = input.streak ?? cur.streak;
+    cur.updatedAt = new Date().toISOString();
+    memory.leaderboard.set(input.playerId, cur);
   }
-  const cur = snap.data() as any;
-  await updateDoc(ref, {
-    wins: input.wins ?? cur.wins ?? 0,
-    losses: input.losses ?? cur.losses ?? 0,
-    streak: input.streak ?? cur.streak ?? 0,
-    updatedAt: now,
-  });
 };
 
 export const listLeaderboard = async (): Promise<LeaderboardEntry[]> => {
-  const snap = await getDocs(collection(db, "leaderboard"));
-  return Promise.all(
-    snap.docs.map(async (s) => {
-      const d = s.data() as any;
-      let playerCodename: string | undefined;
-      try {
-        const p = await getDoc(doc(db, "players", d.playerId));
-        playerCodename = p.data()?.codename;
-      } catch {}
-      const updatedAt = d.updatedAt?.toDate?.().toISOString?.() ?? new Date().toISOString();
-      return {
-        id: s.id,
-        playerId: d.playerId,
-        playerCodename,
-        wins: d.wins ?? 0,
-        losses: d.losses ?? 0,
-        streak: d.streak ?? 0,
-        updatedAt,
-      } as LeaderboardEntry;
-    })
-  );
+  return Array.from(memory.leaderboard.values());
 };
 
-// END
+// --- END DEV STUB ---


### PR DESCRIPTION
## Summary
- replace the Firebase implementation with a temporary in-memory dev stub so every expected export exists
- provide fake auth, database, and data helpers backed by simple maps to unblock local `/training` testing

## Testing
- ❌ `npm run build` *(fails due to type constraints in the wider app when using the stub)*

------
https://chatgpt.com/codex/tasks/task_e_68cda9785274832eac6b8a508dbd6f24