### PR TITLE
Add Phaser offline training prototype

### DIFF
--- a/src/game/entities/Dummy.ts
+++ b/src/game/entities/Dummy.ts
@@ -1,53 +1,55 @@
 import Phaser from "phaser";
 
-const BODY_RADIUS = 12;
+const DUMMY_WIDTH = 40;
+const DUMMY_HEIGHT = 64;
+const DUMMY_COLOR = 0xfacc15;
+const MAX_HP = 100;
 
-function ensureCircleTexture(scene: Phaser.Scene, key: string, radius: number) {
-  if (scene.textures.exists(key)) return;
-  const diameter = radius * 2;
-  const graphics = scene.make.graphics({ x: 0, y: 0, add: false });
-  graphics.fillStyle(0xffffff, 1);
-  graphics.fillCircle(radius, radius, radius);
-  graphics.generateTexture(key, diameter, diameter);
-  graphics.destroy();
-}
+export class Dummy extends Phaser.Events.EventEmitter {
+  readonly maxHp = MAX_HP;
+  hp = MAX_HP;
+  readonly sprite: Phaser.GameObjects.Rectangle;
+  readonly body: Phaser.Physics.Arcade.StaticBody;
 
-export class Dummy {
-  sprite: Phaser.Types.Physics.Arcade.ImageWithDynamicBody;
-  hp = 100;
-
-  private direction: 1 | -1 = -1;
-  private changeTimer = 0;
-
-  constructor(scene: Phaser.Scene, x: number, y: number, private readonly tint = 0xfacc15) {
-    ensureCircleTexture(scene, "dummy-circle", BODY_RADIUS);
-    this.sprite = scene.physics.add.image(x, y, "dummy-circle").setTint(tint);
-    this.sprite.setCircle(BODY_RADIUS).setOffset(-BODY_RADIUS, -BODY_RADIUS);
-    this.sprite.setCollideWorldBounds(true).setImmovable(false).setMaxVelocity(200, 900);
+  constructor(private scene: Phaser.Scene, x: number, y: number) {
+    super();
+    this.sprite = scene.add.rectangle(x, y, DUMMY_WIDTH, DUMMY_HEIGHT, DUMMY_COLOR);
+    scene.physics.add.existing(this.sprite, true);
+    this.body = this.sprite.body as Phaser.Physics.Arcade.StaticBody;
+    this.body.updateFromGameObject();
   }
 
-  update(dt: number) {
-    const body = this.sprite.body as Phaser.Physics.Arcade.Body;
-    const onGround = body.blocked.down;
-    this.changeTimer -= dt;
-
-    if (onGround && this.changeTimer <= 0) {
-      this.changeTimer = 1.5 + Math.random();
-      this.direction = Math.random() > 0.5 ? 1 : -1;
-    }
-
-    if (onGround) {
-      body.setVelocityX(this.direction * 60);
-    }
-  }
-
-  takeDamage(amount: number) {
+  receiveDamage(amount: number): boolean {
+    if (amount <= 0) return false;
     this.hp = Math.max(0, this.hp - amount);
-    this.sprite.setTintFill(0xffe08a);
-    window.setTimeout(() => this.sprite.setTint(this.tint), 100);
+    this.emit("dummy:damaged", this.hp);
+    this.flash();
+    const knockedOut = this.hp <= 0;
+    if (knockedOut) {
+      this.emit("dummy:ko");
+      this.scene.time.delayedCall(350, () => {
+        if (!this.sprite.active) return;
+        this.reset();
+      });
+    }
+    return knockedOut;
   }
 
-  healFull() {
-    this.hp = 100;
+  reset() {
+    this.hp = this.maxHp;
+    this.emit("dummy:damaged", this.hp);
+    this.body.updateFromGameObject();
+  }
+
+  destroy() {
+    this.sprite.destroy();
+    this.removeAllListeners();
+  }
+
+  private flash() {
+    this.sprite.setFillStyle(0xfde68a);
+    this.scene.time.delayedCall(100, () => {
+      this.sprite.setFillStyle(DUMMY_COLOR);
+    });
   }
 }

--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -1,64 +1,60 @@
 import Phaser from "phaser";
-import { Inputs } from "../core/Inputs";
+import { bindTrainingControls, TrainingControls, unbindTrainingControls } from "../input/keys";
 
-const BODY_RADIUS = 12;
-const DASH_GAP = 0.25;
-const DASH_DURATION = 0.18;
-const DASH_SPEED = 360;
+const PLAYER_WIDTH = 28;
+const PLAYER_HEIGHT = 48;
+const PLAYER_COLOR = 0x38bdf8;
+const MOVE_ACCEL = 1200;
+const GROUND_DRAG = 1400;
+const AIR_DRAG = 200;
+const MAX_SPEED = 240;
+const JUMP_SPEED = 420;
+const COYOTE_TIME = 0.1;
+const ATTACK_DURATION = 0.1;
+const ATTACK_COOLDOWN = 0.25;
+const ATTACK_WIDTH = 32;
+const ATTACK_HEIGHT = 20;
+const ATTACK_OFFSET = 24;
 
-function ensureCircleTexture(scene: Phaser.Scene, key: string, radius: number) {
-  if (scene.textures.exists(key)) return;
-  const diameter = radius * 2;
-  const graphics = scene.make.graphics({ x: 0, y: 0, add: false });
-  graphics.fillStyle(0xffffff, 1);
-  graphics.fillCircle(radius, radius, radius);
-  graphics.generateTexture(key, diameter, diameter);
-  graphics.destroy();
-}
-
-export class Player {
-  sprite: Phaser.Types.Physics.Arcade.ImageWithDynamicBody;
+export class Player extends Phaser.Events.EventEmitter {
+  readonly maxHp = 100;
+  hp = this.maxHp;
   facing: 1 | -1 = 1;
-  hp = 100;
-  invulnTimer = 0;
-  onGround = false;
-  fireCooldown = 0;
+  readonly sprite: Phaser.GameObjects.Rectangle;
+  readonly body: Phaser.Physics.Arcade.Body;
+  readonly attackHitbox: Phaser.GameObjects.Rectangle;
 
-  private elapsed = 0;
-  private dashTimer = 0;
-  private lastTapLeft = -Infinity;
-  private lastTapRight = -Infinity;
+  private readonly controls: TrainingControls;
+  private attackTimer = 0;
+  private attackCooldown = 0;
+  private attackConsumed = false;
+  private coyoteTimer = 0;
 
-  constructor(
-    private scene: Phaser.Scene,
-    x: number,
-    y: number,
-    private inputs: Inputs,
-    private readonly tint = 0xffffff,
-  ) {
-    ensureCircleTexture(scene, "player-circle", BODY_RADIUS);
-    this.sprite = scene.physics.add.image(x, y, "player-circle").setTint(this.tint);
-    this.sprite.setCircle(BODY_RADIUS).setOffset(-BODY_RADIUS, -BODY_RADIUS);
-    this.sprite
-      .setBounce(0)
-      .setDrag(1200, 0)
-      .setFriction(0, 0)
-      .setCollideWorldBounds(true)
-      .setMaxVelocity(320, 900);
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super();
+
+    this.sprite = scene.add.rectangle(x, y, PLAYER_WIDTH, PLAYER_HEIGHT, PLAYER_COLOR);
+    scene.physics.add.existing(this.sprite);
+    this.body = this.sprite.body as Phaser.Physics.Arcade.Body;
+    this.body.setCollideWorldBounds(true);
+    this.body.setMaxVelocity(MAX_SPEED, 900);
+    this.body.setDrag(GROUND_DRAG, 0);
+    this.body.setSize(PLAYER_WIDTH, PLAYER_HEIGHT, true);
+
+    this.attackHitbox = scene.add.rectangle(x + ATTACK_OFFSET, y, ATTACK_WIDTH, ATTACK_HEIGHT, 0xf97316, 0.5);
+    this.attackHitbox.setVisible(false);
+    scene.physics.add.existing(this.attackHitbox);
+    const attackBody = this.attackHitbox.body as Phaser.Physics.Arcade.Body;
+    attackBody.allowGravity = false;
+    attackBody.setImmovable(true);
+    attackBody.enable = false;
+
+    this.controls = bindTrainingControls(scene.input.keyboard!);
   }
 
   update(dt: number) {
-    const body = this.sprite.body as Phaser.Physics.Arcade.Body;
-    this.elapsed += dt;
-    this.onGround = body.blocked.down;
-
-    const leftDown = this.inputs.isDown("arrowleft") || this.inputs.isDown("a");
-    const rightDown = this.inputs.isDown("arrowright") || this.inputs.isDown("d");
-
-    const leftPressed =
-      this.inputs.consumePress("arrowleft") || this.inputs.consumePress("a");
-    const rightPressed =
-      this.inputs.consumePress("arrowright") || this.inputs.consumePress("d");
+    const leftDown = this.controls.left.isDown;
+    const rightDown = this.controls.right.isDown;
 
     if (leftDown && !rightDown) {
       this.facing = -1;
@@ -66,69 +62,79 @@ export class Player {
       this.facing = 1;
     }
 
-    if (this.onGround) {
-      if (leftPressed) {
-        this.handleDash(-1, body);
-      }
-      if (rightPressed) {
-        this.handleDash(1, body);
-      }
-    }
-
-    const walkSpeed = 180;
-    let vx = 0;
-    if (leftDown && !rightDown) {
-      vx = -walkSpeed;
-    } else if (rightDown && !leftDown) {
-      vx = walkSpeed;
-    }
-
-    if (this.dashTimer > 0) {
-      this.dashTimer = Math.max(0, this.dashTimer - dt);
-      body.setVelocityX(this.facing * DASH_SPEED);
+    const onGround = this.body.blocked.down;
+    if (onGround) {
+      this.coyoteTimer = COYOTE_TIME;
+      this.body.setDrag(GROUND_DRAG, 0);
     } else {
-      body.setVelocityX(vx);
+      this.coyoteTimer = Math.max(0, this.coyoteTimer - dt);
+      this.body.setDrag(AIR_DRAG, 0);
     }
 
-    const wantJump = this.inputs.isDown("arrowup") || this.inputs.isDown("w");
-    if (wantJump && this.onGround) {
-      body.setVelocityY(-360);
-    }
-
-    this.fireCooldown = Math.max(0, this.fireCooldown - dt);
-    this.invulnTimer = Math.max(0, this.invulnTimer - dt);
-  }
-
-  private handleDash(direction: 1 | -1, body: Phaser.Physics.Arcade.Body) {
-    const now = this.elapsed;
-    if (direction === -1) {
-      if (now - this.lastTapLeft <= DASH_GAP) {
-        this.triggerDash(direction, body);
+    if (leftDown === rightDown) {
+      this.body.setAccelerationX(0);
+      if (!onGround && Math.abs(this.body.velocity.x) < 10) {
+        this.body.setVelocityX(0);
       }
-      this.lastTapLeft = now;
     } else {
-      if (now - this.lastTapRight <= DASH_GAP) {
-        this.triggerDash(direction, body);
+      const accel = leftDown ? -MOVE_ACCEL : MOVE_ACCEL;
+      this.body.setAccelerationX(accel);
+    }
+
+    if (this.controls.jump.some((key) => Phaser.Input.Keyboard.JustDown(key))) {
+      if (onGround || this.coyoteTimer > 0) {
+        this.body.setVelocityY(-JUMP_SPEED);
+        this.coyoteTimer = 0;
       }
-      this.lastTapRight = now;
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.controls.attack) && this.attackCooldown <= 0) {
+      this.startAttack();
+    }
+
+    this.attackCooldown = Math.max(0, this.attackCooldown - dt);
+    this.attackTimer = Math.max(0, this.attackTimer - dt);
+
+    const attackBody = this.attackHitbox.body as Phaser.Physics.Arcade.Body;
+    const hitboxX = this.sprite.x + this.facing * ATTACK_OFFSET;
+    attackBody.reset(hitboxX, this.sprite.y);
+    this.attackHitbox.setPosition(hitboxX, this.sprite.y);
+
+    const active = this.attackTimer > 0;
+    attackBody.enable = active;
+    this.attackHitbox.setVisible(active);
+    if (!active) {
+      this.attackConsumed = false;
     }
   }
 
-  private triggerDash(direction: 1 | -1, body: Phaser.Physics.Arcade.Body) {
-    this.facing = direction;
-    this.dashTimer = DASH_DURATION;
-    body.setVelocity(direction * DASH_SPEED, body.velocity.y);
+  isAttackActive() {
+    return this.attackTimer > 0;
   }
 
-  takeDamage(amount: number) {
-    if (this.invulnTimer > 0) return;
-    this.hp = Math.max(0, this.hp - amount);
-    this.invulnTimer = 0.3;
-    this.sprite.setTintFill(0xfff1f2);
-    window.setTimeout(() => this.sprite.setTint(this.tint), 120);
+  registerHit(): boolean {
+    if (!this.isAttackActive() || this.attackConsumed) {
+      return false;
+    }
+    this.attackConsumed = true;
+    this.emit("player:hit");
+    return true;
   }
 
   healFull() {
-    this.hp = 100;
+    this.hp = this.maxHp;
+  }
+
+  destroy() {
+    unbindTrainingControls(this.controls);
+    this.attackHitbox.destroy();
+    this.sprite.destroy();
+    this.removeAllListeners();
+  }
+
+  private startAttack() {
+    this.attackTimer = ATTACK_DURATION;
+    this.attackCooldown = ATTACK_COOLDOWN;
+    this.attackConsumed = false;
   }
 }

--- a/src/game/input/keys.ts
+++ b/src/game/input/keys.ts
@@ -1,0 +1,32 @@
+import Phaser from "phaser";
+
+export const KEY_A = Phaser.Input.Keyboard.KeyCodes.A;
+export const KEY_D = Phaser.Input.Keyboard.KeyCodes.D;
+export const KEY_W = Phaser.Input.Keyboard.KeyCodes.W;
+export const KEY_SPACE = Phaser.Input.Keyboard.KeyCodes.SPACE;
+export const KEY_J = Phaser.Input.Keyboard.KeyCodes.J;
+
+export interface TrainingControls {
+  left: Phaser.Input.Keyboard.Key;
+  right: Phaser.Input.Keyboard.Key;
+  jump: Phaser.Input.Keyboard.Key[];
+  attack: Phaser.Input.Keyboard.Key;
+}
+
+export function bindTrainingControls(
+  keyboard: Phaser.Input.Keyboard.KeyboardPlugin,
+): TrainingControls {
+  return {
+    left: keyboard.addKey(KEY_A, false, false),
+    right: keyboard.addKey(KEY_D, false, false),
+    jump: [keyboard.addKey(KEY_W, false, false), keyboard.addKey(KEY_SPACE, false, false)],
+    attack: keyboard.addKey(KEY_J, false, false),
+  };
+}
+
+export function unbindTrainingControls(controls: TrainingControls) {
+  controls.left.destroy();
+  controls.right.destroy();
+  controls.jump.forEach((key) => key.destroy());
+  controls.attack.destroy();
+}

--- a/src/game/ui/HUD.ts
+++ b/src/game/ui/HUD.ts
@@ -1,0 +1,59 @@
+import Phaser from "phaser";
+import { Dummy } from "../entities/Dummy";
+import { Player } from "../entities/Player";
+
+const HUD_WIDTH = 240;
+const HUD_HEIGHT = 70;
+const BAR_WIDTH = 200;
+const BAR_HEIGHT = 12;
+
+export class HUD {
+  private readonly graphics: Phaser.GameObjects.Graphics;
+  private readonly debugText: Phaser.GameObjects.Text;
+
+  constructor(
+    private scene: Phaser.Scene,
+    private player: Player,
+    private dummy: Dummy,
+  ) {
+    this.graphics = scene.add.graphics({ x: 16, y: 16 });
+    this.graphics.setScrollFactor(0);
+
+    this.debugText = scene.add.text(16, 16 + HUD_HEIGHT, "", {
+      fontFamily: "monospace",
+      fontSize: "14px",
+      color: "#cbd5f5",
+    });
+    this.debugText.setScrollFactor(0);
+  }
+
+  update() {
+    const playerRatio = Phaser.Math.Clamp(this.player.hp / this.player.maxHp, 0, 1);
+    const dummyRatio = Phaser.Math.Clamp(this.dummy.hp / this.dummy.maxHp, 0, 1);
+
+    this.graphics.clear();
+    this.graphics.fillStyle(0x0f172a, 0.85);
+    this.graphics.fillRoundedRect(0, 0, HUD_WIDTH, HUD_HEIGHT, 8);
+
+    this.graphics.fillStyle(0x1e293b, 1);
+    this.graphics.fillRoundedRect(20, 16, BAR_WIDTH, BAR_HEIGHT, 6);
+    this.graphics.fillRoundedRect(20, 40, BAR_WIDTH, BAR_HEIGHT, 6);
+
+    this.graphics.fillStyle(0x38bdf8, 1);
+    this.graphics.fillRoundedRect(20, 16, BAR_WIDTH * playerRatio, BAR_HEIGHT, 6);
+
+    this.graphics.fillStyle(0xfacc15, 1);
+    this.graphics.fillRoundedRect(20, 40, BAR_WIDTH * dummyRatio, BAR_HEIGHT, 6);
+
+    const fps = this.scene.game.loop.actualFps;
+    const { x, y } = this.player.sprite;
+    this.debugText.setText(
+      [`Player HP: ${this.player.hp}`, `Dummy HP: ${this.dummy.hp}`, `FPS: ${fps.toFixed(0)}`, `Pos: ${x.toFixed(1)}, ${y.toFixed(1)}`].join("\n"),
+    );
+  }
+
+  destroy() {
+    this.graphics.destroy();
+    this.debugText.destroy();
+  }
+}

--- a/src/pages/TrainingPage.tsx
+++ b/src/pages/TrainingPage.tsx
@@ -19,7 +19,7 @@ const TrainingPage: React.FC = () => {
       height: 540,
       parent: containerRef.current,
       backgroundColor: "#0f1115",
-      physics: { default: "arcade", arcade: { gravity: { y: 900 }, debug: false } },
+      physics: { default: "arcade", arcade: { gravity: { x: 0, y: 900 }, debug: false } },
       scene: [TrainingScene],
     };
 


### PR DESCRIPTION
## Summary
- add keyboard bindings helper and rebuild the Player entity with jump, coyote time, and an attack hitbox
- introduce a static Dummy target plus HUD overlays to track health and debug info
- replace the training scene with Phaser wiring for ground, collisions, KO feedback, and cleanup
- ensure the training route boots Phaser with explicit gravity configuration

## Testing
- npm run build *(fails: repository still contains template shell heredoc markers that break TypeScript compilation, e.g. `cat > src/App.tsx <<'TS'`)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc5fad310832e825bfadd31c029c0