### PR TITLE
feat: netcode referee MVP (1v1 on Firebase)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,6 +32,17 @@ service cloud.firestore {
       allow write: if request.auth != null; // TEMP for dev
     }
 
+    // Matches + runtime netcode data (DEV TEMP)
+    match /matches/{matchId} {
+      allow read, write: if request.auth != null;
+      match /inputs/{tick} {
+        allow read, write: if request.auth != null;
+      }
+      match /snapshots/{tick} {
+        allow read, write: if request.auth != null;
+      }
+    }
+
     // Read-only metadata
     match /meta/{doc} {
       allow read: if true;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-cat > src/App.tsx <<'TS'
 import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
@@ -34,4 +33,3 @@ export default function App() {
     </Routes>
   );
 }
-TS

--- a/src/game/attacks/Fireball.ts
+++ b/src/game/attacks/Fireball.ts
@@ -5,7 +5,8 @@ const FIREBALL_RADIUS = 6;
 function ensureCircleTexture(scene: Phaser.Scene, key: string, radius: number) {
   if (scene.textures.exists(key)) return;
   const diameter = radius * 2;
-  const graphics = scene.make.graphics({ x: 0, y: 0, add: false });
+  const graphics = scene.add.graphics({ x: 0, y: 0 });
+  graphics.setVisible(false);
   graphics.fillStyle(0xffffff, 1);
   graphics.fillCircle(radius, radius, radius);
   graphics.generateTexture(key, diameter, diameter);

--- a/src/game/input/KeyBinder.ts
+++ b/src/game/input/KeyBinder.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+
+export type KeyIntentState = {
+  left: boolean;
+  right: boolean;
+  up: boolean;
+  jump: boolean;
+  attack: boolean;
+  seq: number;
+};
+
+const DEFAULT_STATE: KeyIntentState = {
+  left: false,
+  right: false,
+  up: false,
+  jump: false,
+  attack: false,
+  seq: 0,
+};
+
+const KEY_CODE_MAP: Record<string, keyof KeyIntentState | undefined> = {
+  KeyA: "left",
+  ArrowLeft: "left",
+  KeyD: "right",
+  ArrowRight: "right",
+  KeyW: "up",
+  ArrowUp: "up",
+  Space: "jump",
+  KeyJ: "attack",
+};
+
+export function useKeyBinder(target: Document | Window | null = typeof window !== "undefined" ? window : null) {
+  const stateRef = useRef<KeyIntentState>({ ...DEFAULT_STATE });
+
+  useEffect(() => {
+    if (!target) {
+      return;
+    }
+
+    const downHandler = (event: KeyboardEvent) => {
+      const key = KEY_CODE_MAP[event.code];
+      if (!key) return;
+      if (key === "seq") return;
+      const current = stateRef.current;
+      if (!current[key]) {
+        stateRef.current = { ...current, [key]: true, seq: current.seq + 1 };
+      }
+    };
+
+    const upHandler = (event: KeyboardEvent) => {
+      const key = KEY_CODE_MAP[event.code];
+      if (!key) return;
+      if (key === "seq") return;
+      const current = stateRef.current;
+      if (current[key]) {
+        stateRef.current = { ...current, [key]: false, seq: current.seq + 1 };
+      }
+    };
+
+    const downTarget: any = "addEventListener" in target ? target : window;
+    const upTarget: any = downTarget;
+
+    downTarget.addEventListener("keydown", downHandler);
+    upTarget.addEventListener("keyup", upHandler);
+
+    return () => {
+      downTarget.removeEventListener("keydown", downHandler);
+      upTarget.removeEventListener("keyup", upHandler);
+    };
+  }, [target]);
+
+  return stateRef;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-cat > src/main.tsx <<'TS'
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -20,4 +19,3 @@ root.render(
     </BrowserRouter>
   </React.StrictMode>
 );
-TS

--- a/src/netcode/clientLoop.ts
+++ b/src/netcode/clientLoop.ts
@@ -1,0 +1,43 @@
+import type { InputIntent, Snapshot } from "../types/netcode";
+import { subscribeSnapshots, writeInput } from "./refereeStore";
+
+export function startClientLoop(
+  matchId: string,
+  slot: 1 | 2,
+  getLocalIntent: () => InputIntent,
+  onSnapshot: (s: Snapshot) => void,
+): () => void {
+  let disposed = false;
+  let latestTick = 0;
+  let lastSeqSent = -1;
+  let writing = false;
+
+  const unsubscribe = subscribeSnapshots(matchId, (snap) => {
+    latestTick = Math.max(latestTick, snap.t);
+    onSnapshot(snap);
+  });
+
+  const interval = setInterval(() => {
+    if (disposed || writing) return;
+    const intent = getLocalIntent();
+    if (intent.seq === lastSeqSent) return;
+    writing = true;
+    const targetTick = latestTick + 1;
+    writeInput(matchId, targetTick, slot, intent)
+      .then(() => {
+        lastSeqSent = intent.seq;
+      })
+      .catch((err) => {
+        console.warn("[clientLoop] failed to write input", err);
+      })
+      .finally(() => {
+        writing = false;
+      });
+  }, 50);
+
+  return () => {
+    disposed = true;
+    clearInterval(interval);
+    unsubscribe();
+  };
+}

--- a/src/netcode/refereeLoop.ts
+++ b/src/netcode/refereeLoop.ts
@@ -1,0 +1,296 @@
+import type { InputIntent, Snapshot } from "../types/netcode";
+import { nowMs } from "../utils/time";
+import {
+  getInputsForTick,
+  getLatestSnapshot,
+  subscribeMatch,
+  writeSnapshot,
+} from "./refereeStore";
+
+const DT = 0.05;
+const WORLD_WIDTH = 960;
+const WORLD_HEIGHT = 540;
+const GROUND_HEIGHT = 40;
+const PLAYER_WIDTH = 28;
+const PLAYER_HEIGHT = 48;
+const PLAYER_HALF_WIDTH = PLAYER_WIDTH / 2;
+const PLAYER_HALF_HEIGHT = PLAYER_HEIGHT / 2;
+const GROUND_Y = WORLD_HEIGHT - GROUND_HEIGHT - PLAYER_HALF_HEIGHT;
+const CEILING_Y = PLAYER_HALF_HEIGHT;
+const GRAVITY = 900;
+const MOVE_ACCEL = 1200;
+const MAX_SPEED = 240;
+const GROUND_FRICTION = 900;
+const AIR_FRICTION = 200;
+const JUMP_SPEED = 420;
+const MIN_SEPARATION = 36;
+const ATTACK_OFFSET = 28;
+const ATTACK_RANGE = 40;
+const ATTACK_HEIGHT = 60;
+const ATTACK_DURATION = 0.12;
+const ATTACK_COOLDOWN = 0.25;
+const DAMAGE = 10;
+
+interface PlayerMeta {
+  attackTimer: number;
+  attackCooldown: number;
+  attackConsumed: boolean;
+  prevAttack: boolean;
+  prevJump: boolean;
+  facing: 1 | -1;
+}
+
+interface SnapshotMeta {
+  p1: PlayerMeta;
+  p2: PlayerMeta;
+}
+
+const snapshotMeta = new WeakMap<Snapshot, SnapshotMeta>();
+
+function makePlayerMeta(): PlayerMeta {
+  return {
+    attackTimer: 0,
+    attackCooldown: 0,
+    attackConsumed: false,
+    prevAttack: false,
+    prevJump: false,
+    facing: 1,
+  };
+}
+
+function makeSnapshotMeta(): SnapshotMeta {
+  return { p1: makePlayerMeta(), p2: makePlayerMeta() };
+}
+
+function ensureMeta(snapshot: Snapshot): SnapshotMeta {
+  let meta = snapshotMeta.get(snapshot);
+  if (!meta) {
+    meta = makeSnapshotMeta();
+    snapshotMeta.set(snapshot, meta);
+  }
+  return meta;
+}
+
+function approachZero(value: number, delta: number) {
+  if (value > 0) {
+    return Math.max(0, value - delta);
+  }
+  if (value < 0) {
+    return Math.min(0, value + delta);
+  }
+  return 0;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function createInitialSnapshot(): Snapshot {
+  const snapshot: Snapshot = {
+    t: 0,
+    p1: { x: 240, y: GROUND_Y, vx: 0, vy: 0, hp: 100 },
+    p2: { x: 720, y: GROUND_Y, vx: 0, vy: 0, hp: 100 },
+    events: [],
+    ts: nowMs(),
+  };
+  snapshotMeta.set(snapshot, makeSnapshotMeta());
+  return snapshot;
+}
+
+function updateFacing(meta: PlayerMeta, input: InputIntent | undefined, selfX: number, otherX: number) {
+  if (input?.left && !input.right) {
+    meta.facing = -1;
+  } else if (input?.right && !input.left) {
+    meta.facing = 1;
+  } else if (Math.abs(selfX - otherX) > 2) {
+    meta.facing = selfX < otherX ? 1 : -1;
+  }
+}
+
+function handleAttack(
+  attacker: { state: Snapshot["p1"]; meta: PlayerMeta },
+  defender: { state: Snapshot["p1"]; meta: PlayerMeta },
+  events: string[],
+  defenderLabel: "p1" | "p2",
+) {
+  if (attacker.meta.attackTimer <= 0 || attacker.meta.attackConsumed) {
+    return;
+  }
+  const hitX = attacker.state.x + attacker.meta.facing * ATTACK_OFFSET;
+  const dx = Math.abs(hitX - defender.state.x);
+  const dy = Math.abs(attacker.state.y - defender.state.y);
+  if (dx <= ATTACK_RANGE && dy <= ATTACK_HEIGHT) {
+    attacker.meta.attackConsumed = true;
+    defender.state.hp = Math.max(0, defender.state.hp - DAMAGE);
+    events.push(`${defenderLabel}:hit`);
+    if (defender.state.hp <= 0) {
+      defender.state.hp = 100;
+      events.push(`${defenderLabel}:ko`);
+    }
+  }
+}
+
+function stepPlayer(
+  current: Snapshot["p1"],
+  input: InputIntent | undefined,
+  meta: PlayerMeta,
+): Snapshot["p1"] {
+  let vx = current.vx;
+  let vy = current.vy;
+  const onGround = current.y >= GROUND_Y - 0.5;
+  vy += GRAVITY * DT;
+
+  if (input?.left && !input.right) {
+    vx -= MOVE_ACCEL * DT;
+  } else if (input?.right && !input.left) {
+    vx += MOVE_ACCEL * DT;
+  } else {
+    const friction = onGround ? GROUND_FRICTION : AIR_FRICTION;
+    vx = approachZero(vx, friction * DT);
+  }
+
+  const wantsJump = (input?.jump || input?.up) ?? false;
+  if (wantsJump && !meta.prevJump && onGround) {
+    vy = -JUMP_SPEED;
+  }
+  meta.prevJump = wantsJump;
+
+  if (meta.attackCooldown > 0) {
+    meta.attackCooldown = Math.max(0, meta.attackCooldown - DT);
+  }
+  if (meta.attackTimer > 0) {
+    meta.attackTimer = Math.max(0, meta.attackTimer - DT);
+    if (meta.attackTimer === 0) {
+      meta.attackConsumed = false;
+    }
+  }
+
+  const attackHeld = !!input?.attack;
+  if (attackHeld && !meta.prevAttack && meta.attackCooldown <= 0) {
+    meta.attackTimer = ATTACK_DURATION;
+    meta.attackCooldown = ATTACK_COOLDOWN;
+    meta.attackConsumed = false;
+  }
+  meta.prevAttack = attackHeld;
+
+  vx = clamp(vx, -MAX_SPEED, MAX_SPEED);
+
+  let nx = current.x + vx * DT;
+  let ny = current.y + vy * DT;
+
+  if (ny >= GROUND_Y) {
+    ny = GROUND_Y;
+    vy = 0;
+  } else if (ny <= CEILING_Y) {
+    ny = CEILING_Y;
+    vy = 0;
+  }
+
+  nx = clamp(nx, PLAYER_HALF_WIDTH, WORLD_WIDTH - PLAYER_HALF_WIDTH);
+
+  return { x: nx, y: ny, vx, vy, hp: current.hp };
+}
+
+export function applyRules(
+  prev: Snapshot,
+  inputs: { p1?: InputIntent; p2?: InputIntent },
+): Snapshot {
+  const prevMeta = ensureMeta(prev);
+  const nextMeta: SnapshotMeta = {
+    p1: { ...prevMeta.p1 },
+    p2: { ...prevMeta.p2 },
+  };
+
+  updateFacing(nextMeta.p1, inputs.p1, prev.p1.x, prev.p2.x);
+  updateFacing(nextMeta.p2, inputs.p2, prev.p2.x, prev.p1.x);
+
+  const nextP1 = stepPlayer(prev.p1, inputs.p1, nextMeta.p1);
+  const nextP2 = stepPlayer(prev.p2, inputs.p2, nextMeta.p2);
+
+  let dx = nextP2.x - nextP1.x;
+  const separation = Math.abs(dx);
+  if (separation < MIN_SEPARATION && separation > 0) {
+    const push = (MIN_SEPARATION - separation) / 2;
+    const direction = dx >= 0 ? -1 : 1;
+    nextP1.x = clamp(nextP1.x + direction * push, PLAYER_HALF_WIDTH, WORLD_WIDTH - PLAYER_HALF_WIDTH);
+    nextP2.x = clamp(nextP2.x - direction * push, PLAYER_HALF_WIDTH, WORLD_WIDTH - PLAYER_HALF_WIDTH);
+    dx = nextP2.x - nextP1.x;
+  }
+
+  const events: string[] = [];
+
+  handleAttack({ state: nextP1, meta: nextMeta.p1 }, { state: nextP2, meta: nextMeta.p2 }, events, "p2");
+  handleAttack({ state: nextP2, meta: nextMeta.p2 }, { state: nextP1, meta: nextMeta.p1 }, events, "p1");
+
+  const snapshot: Snapshot = {
+    t: prev.t + 1,
+    p1: nextP1,
+    p2: nextP2,
+    events: events.length ? events : undefined,
+    ts: nowMs(),
+  };
+  snapshotMeta.set(snapshot, nextMeta);
+  return snapshot;
+}
+
+export function startRefereeLoop(
+  matchId: string,
+  opts: { onTick?: (t: number) => void } = {},
+): () => void {
+  let disposed = false;
+  let ticking = false;
+  let latestSnapshot: Snapshot | null = null;
+  let initialized = false;
+
+  const initPromise = (async () => {
+    const existing = await getLatestSnapshot(matchId);
+    if (existing) {
+      latestSnapshot = existing;
+      ensureMeta(existing);
+    } else {
+      latestSnapshot = createInitialSnapshot();
+      await writeSnapshot(matchId, latestSnapshot.t, latestSnapshot);
+    }
+    initialized = true;
+  })();
+
+  const unsubscribeMatch = subscribeMatch(matchId, (match) => {
+    if (latestSnapshot && match.tick > latestSnapshot.t) {
+      getLatestSnapshot(matchId)
+        .then((snap) => {
+          if (snap) {
+            latestSnapshot = snap;
+            ensureMeta(snap);
+          }
+        })
+        .catch((err) => console.warn("[refereeLoop] refresh snapshot failed", err));
+    }
+  });
+
+  const interval = setInterval(() => {
+    if (disposed || ticking || !initialized || !latestSnapshot) return;
+    ticking = true;
+    const nextTick = latestSnapshot.t + 1;
+    getInputsForTick(matchId, nextTick)
+      .then((inputs) => {
+        const snap = applyRules(latestSnapshot!, inputs);
+        latestSnapshot = snap;
+        return writeSnapshot(matchId, snap.t, snap).then(() => {
+          opts.onTick?.(snap.t);
+        });
+      })
+      .catch((err) => {
+        console.warn("[refereeLoop] tick failed", err);
+      })
+      .finally(() => {
+        ticking = false;
+      });
+  }, 50);
+
+  return () => {
+    disposed = true;
+    clearInterval(interval);
+    unsubscribeMatch();
+    void initPromise;
+  };
+}

--- a/src/netcode/refereeStore.ts
+++ b/src/netcode/refereeStore.ts
@@ -1,0 +1,207 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import type { InputIntent, MatchDoc, MatchStatus, Snapshot } from "../types/netcode";
+import { nowMs } from "../utils/time";
+
+const matchesCollection = collection(db, "matches");
+
+function isoNow() {
+  return new Date(nowMs()).toISOString();
+}
+
+function normalizeMatch(id: string, data: any): MatchDoc {
+  const created = data.createdAt?.toDate?.()?.toISOString?.() ?? data.createdAt ?? isoNow();
+  const updated = data.updatedAt?.toDate?.()?.toISOString?.() ?? data.updatedAt ?? undefined;
+  const players = Array.isArray(data.players) ? data.players.map((p: any) => ({
+    playerId: String(p?.playerId ?? ""),
+    codename: String(p?.codename ?? ""),
+  })) : [];
+  return {
+    id,
+    arenaId: String(data.arenaId ?? ""),
+    players,
+    status: (data.status ?? "waiting") as MatchStatus,
+    tick: Number(data.tick ?? 0),
+    createdAt: created,
+    updatedAt: updated,
+  };
+}
+
+function normalizeSnapshot(docId: string, data: any): Snapshot {
+  return {
+    t: Number(data.t ?? Number(docId) ?? 0),
+    p1: {
+      x: Number(data.p1?.x ?? 0),
+      y: Number(data.p1?.y ?? 0),
+      vx: Number(data.p1?.vx ?? 0),
+      vy: Number(data.p1?.vy ?? 0),
+      hp: Number(data.p1?.hp ?? 100),
+    },
+    p2: {
+      x: Number(data.p2?.x ?? 0),
+      y: Number(data.p2?.y ?? 0),
+      vx: Number(data.p2?.vx ?? 0),
+      vy: Number(data.p2?.vy ?? 0),
+      hp: Number(data.p2?.hp ?? 100),
+    },
+    events: Array.isArray(data.events) ? data.events.map((v: any) => String(v)) : undefined,
+    ts: Number(data.ts ?? nowMs()),
+  };
+}
+
+export async function createMatch(
+  arenaId: string,
+  players: { playerId: string; codename: string }[],
+): Promise<string> {
+  const createdAt = isoNow();
+  const docRef = await addDoc(matchesCollection, {
+    arenaId,
+    players,
+    status: players.length >= 2 ? "active" : "waiting",
+    tick: 0,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  return docRef.id;
+}
+
+export async function getMatch(matchId: string): Promise<MatchDoc | null> {
+  const ref = doc(db, "matches", matchId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return normalizeMatch(snap.id, snap.data());
+}
+
+export function subscribeMatch(matchId: string, onMatch: (match: MatchDoc) => void): () => void {
+  const ref = doc(db, "matches", matchId);
+  return onSnapshot(ref, (snap) => {
+    if (!snap.exists()) return;
+    onMatch(normalizeMatch(snap.id, snap.data()));
+  });
+}
+
+export async function joinOrCreate1v1(
+  arenaId: string,
+  player: { playerId: string; codename: string },
+): Promise<{ matchId: string; role: "referee" | "client" }> {
+  const waitingQuery = query(
+    matchesCollection,
+    where("arenaId", "==", arenaId),
+    where("status", "==", "waiting"),
+  );
+  const waiting = await getDocs(waitingQuery);
+
+  for (const docSnap of waiting.docs) {
+    const data = docSnap.data();
+    const players = Array.isArray(data.players) ? [...data.players] : [];
+    const filtered = players.filter((p: any) => p?.playerId);
+    const existingIndex = filtered.findIndex((p: any) => p.playerId === player.playerId);
+    let nextPlayers = filtered;
+    if (existingIndex === -1 && filtered.length < 2) {
+      nextPlayers = [...filtered, player];
+    }
+    const slot = nextPlayers.findIndex((p: any) => p.playerId === player.playerId);
+    if (slot === -1) {
+      continue;
+    }
+    const nextStatus: MatchStatus = nextPlayers.length >= 2 ? "active" : "waiting";
+    await updateDoc(doc(db, "matches", docSnap.id), {
+      players: nextPlayers,
+      status: nextStatus,
+      updatedAt: isoNow(),
+    });
+    return { matchId: docSnap.id, role: slot === 0 ? "referee" : "client" };
+  }
+
+  const matchId = await createMatch(arenaId, [player]);
+  return { matchId, role: "referee" };
+}
+
+export async function writeInput(
+  matchId: string,
+  tick: number,
+  slot: 1 | 2,
+  input: InputIntent,
+): Promise<void> {
+  const ref = doc(db, "matches", matchId, "inputs", String(tick));
+  const field = slot === 1 ? "p1" : "p2";
+  await setDoc(
+    ref,
+    {
+      t: tick,
+      [field]: input,
+    },
+    { merge: true },
+  );
+}
+
+export async function getInputsForTick(
+  matchId: string,
+  tick: number,
+): Promise<{ p1?: InputIntent; p2?: InputIntent }> {
+  const ref = doc(db, "matches", matchId, "inputs", String(tick));
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return {};
+  const data = snap.data() as any;
+  return {
+    p1: data.p1 as InputIntent | undefined,
+    p2: data.p2 as InputIntent | undefined,
+  };
+}
+
+export async function writeSnapshot(matchId: string, t: number, snap: Snapshot): Promise<void> {
+  const ref = doc(db, "matches", matchId, "snapshots", String(t));
+  await setDoc(ref, { ...snap });
+  await updateDoc(doc(db, "matches", matchId), {
+    tick: t,
+    updatedAt: isoNow(),
+  });
+}
+
+export async function removePlayerFromMatch(matchId: string, playerId: string): Promise<void> {
+  const ref = doc(db, "matches", matchId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return;
+  const data = snap.data() as any;
+  const players = Array.isArray(data.players)
+    ? data.players.filter((p: any) => p?.playerId && p.playerId !== playerId)
+    : [];
+  const nextStatus: MatchStatus = players.length >= 2 ? "active" : players.length === 0 ? "waiting" : "waiting";
+  await updateDoc(ref, {
+    players,
+    status: nextStatus,
+    updatedAt: isoNow(),
+  });
+}
+
+export async function getLatestSnapshot(matchId: string): Promise<Snapshot | null> {
+  const snapsRef = collection(db, "matches", matchId, "snapshots");
+  const q = query(snapsRef, orderBy("t", "desc"), limit(1));
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) return null;
+  const docSnap = snapshot.docs[0];
+  return normalizeSnapshot(docSnap.id, docSnap.data());
+}
+
+export function subscribeSnapshots(matchId: string, onSnap: (snap: Snapshot) => void): () => void {
+  const snapsRef = collection(db, "matches", matchId, "snapshots");
+  const q = query(snapsRef, orderBy("t", "desc"), limit(1));
+  return onSnapshot(q, (snapshot) => {
+    const docSnap = snapshot.docs[0];
+    if (!docSnap) return;
+    onSnap(normalizeSnapshot(docSnap.id, docSnap.data()));
+  });
+}

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -1,71 +1,341 @@
-import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { doc, getDoc } from "firebase/firestore";
-import { db } from "../firebase";
 import type { Arena } from "../types/models";
-import React from "react";
+import { db } from "../firebase";
+import { useAuth } from "../context/AuthContext";
+import { joinArena, leaveArena } from "../db";
+import { joinOrCreate1v1, removePlayerFromMatch, subscribeMatch } from "../netcode/refereeStore";
+import type { MatchDoc, Snapshot } from "../types/netcode";
+import { startClientLoop } from "../netcode/clientLoop";
+import { startRefereeLoop } from "../netcode/refereeLoop";
+import { useKeyBinder } from "../game/input/KeyBinder";
+import { sampleKeyboardIntent } from "../utils/input";
 
+const ARENA_WIDTH = 960;
+const ARENA_HEIGHT = 540;
+const PLAYER_WIDTH = 28;
+const PLAYER_HEIGHT = 48;
+const PLAYER_HALF_WIDTH = PLAYER_WIDTH / 2;
+const PLAYER_HALF_HEIGHT = PLAYER_HEIGHT / 2;
 
-const ArenaPage = () => {
+const ArenaPage: React.FC = () => {
   const { arenaId } = useParams<{ arenaId: string }>();
+  const navigate = useNavigate();
+  const { player } = useAuth();
+
   const [arena, setArena] = useState<Arena | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [matchId, setMatchId] = useState<string | null>(null);
+  const [match, setMatch] = useState<MatchDoc | null>(null);
+  const [role, setRole] = useState<"referee" | "client" | null>(null);
+  const [latestSnapshot, setLatestSnapshot] = useState<Snapshot | null>(null);
+  const [tick, setTick] = useState(0);
+
+  const keysRef = useKeyBinder();
+  const matchIdRef = useRef<string | null>(null);
+
+  const clientLoopCleanup = useRef<() => void>();
+  const refereeLoopCleanup = useRef<() => void>();
 
   useEffect(() => {
+    if (!arenaId) {
+      setError("Arena not found");
+      return;
+    }
+    let cancelled = false;
+
     const loadArena = async () => {
-      if (!arenaId) {
-        setError("Arena not found");
-        return;
-      }
       try {
         const arenaDoc = await getDoc(doc(db, "arenas", arenaId));
         if (!arenaDoc.exists()) {
-          setError("Arena not found");
+          if (!cancelled) setError("Arena not found");
           return;
         }
         const data = arenaDoc.data();
-        setArena({
-          id: arenaDoc.id,
-          name: data.name,
-          description: data.description ?? "",
-          capacity: data.capacity ?? undefined,
-          isActive: Boolean(data.isActive),
-          createdAt: data.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
-        });
+        if (!cancelled) {
+          setArena({
+            id: arenaDoc.id,
+            name: data.name,
+            description: data.description ?? "",
+            capacity: data.capacity ?? undefined,
+            isActive: Boolean(data.isActive),
+            createdAt: data.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
+          });
+        }
       } catch (err) {
         console.error(err);
-        setError("Failed to load arena");
+        if (!cancelled) setError("Failed to load arena");
       }
     };
 
     loadArena().catch((err) => console.error(err));
+
+    return () => {
+      cancelled = true;
+    };
   }, [arenaId]);
 
+  useEffect(() => {
+    if (!arenaId || !player) {
+      return;
+    }
+    let mounted = true;
+
+    joinArena(arenaId, player.id, player.codename).catch((err) => {
+      console.warn("[ArenaPage] failed to join presence", err);
+    });
+
+    joinOrCreate1v1(arenaId, { playerId: player.id, codename: player.codename })
+      .then((res) => {
+        if (!mounted) return;
+        setMatchId(res.matchId);
+        setRole(res.role);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError("Failed to join match");
+      });
+
+    return () => {
+      mounted = false;
+      clientLoopCleanup.current?.();
+      refereeLoopCleanup.current?.();
+      clientLoopCleanup.current = undefined;
+      refereeLoopCleanup.current = undefined;
+      if (arenaId && player) {
+        leaveArena(arenaId, player.id).catch((err) => {
+          console.warn("[ArenaPage] failed to leave presence", err);
+        });
+        if (matchIdRef.current) {
+          removePlayerFromMatch(matchIdRef.current, player.id).catch((err) => {
+            console.warn("[ArenaPage] failed to update match on exit", err);
+          });
+        }
+      }
+    };
+  }, [arenaId, player]);
+
+  useEffect(() => {
+    matchIdRef.current = matchId;
+  }, [matchId]);
+
+  useEffect(() => {
+    if (!matchId) return;
+    setLatestSnapshot(null);
+    setTick(0);
+    const unsubscribe = subscribeMatch(matchId, (doc) => {
+      setMatch(doc);
+      setTick(doc.tick);
+      if (player) {
+        const slot = doc.players.findIndex((p) => p.playerId === player.id);
+        if (slot === 0) {
+          setRole("referee");
+        } else if (slot === 1) {
+          setRole("client");
+        } else {
+          setRole(null);
+        }
+      }
+    });
+    return unsubscribe;
+  }, [matchId, player]);
+
+  const slot = useMemo(() => {
+    if (!match || !player) return null;
+    const idx = match.players.findIndex((p) => p.playerId === player.id);
+    if (idx === -1) return null;
+    return (idx + 1) as 1 | 2;
+  }, [match, player]);
+
+  const getLocalIntent = useCallback(() => sampleKeyboardIntent(keysRef), [keysRef]);
+
+  useEffect(() => {
+    if (!matchId || !slot || !role) {
+      return;
+    }
+
+    clientLoopCleanup.current?.();
+    refereeLoopCleanup.current?.();
+
+    clientLoopCleanup.current = startClientLoop(matchId, slot, getLocalIntent, (snap) => {
+      setLatestSnapshot(snap);
+      setTick(snap.t);
+    });
+
+    if (role === "referee") {
+      refereeLoopCleanup.current = startRefereeLoop(matchId, {
+        onTick: (t) => setTick(t),
+      });
+    } else {
+      refereeLoopCleanup.current = undefined;
+    }
+
+    return () => {
+      clientLoopCleanup.current?.();
+      refereeLoopCleanup.current?.();
+      clientLoopCleanup.current = undefined;
+      refereeLoopCleanup.current = undefined;
+    };
+  }, [matchId, slot, role, getLocalIntent]);
+
+  useEffect(() => {
+    return () => {
+      clientLoopCleanup.current?.();
+      refereeLoopCleanup.current?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (role) {
+      return;
+    }
+    clientLoopCleanup.current?.();
+    refereeLoopCleanup.current?.();
+    clientLoopCleanup.current = undefined;
+    refereeLoopCleanup.current = undefined;
+  }, [role]);
+
+  const statusRibbon = (
+    <div
+      style={{
+        background: "#111827",
+        color: "#e5e7eb",
+        padding: "8px 12px",
+        borderRadius: "8px",
+        marginBottom: "16px",
+        fontSize: "14px",
+      }}
+    >
+      Match: {matchId ?? "…"} · Role: {role ?? "–"} · Tick: {tick}
+    </div>
+  );
+
+  const waitingNotice = match && match.status !== "active" ? (
+    <p style={{ color: "#fbbf24", marginBottom: "12px" }}>Waiting for another player…</p>
+  ) : null;
+
+  const renderSnapshot = () => {
+    if (!latestSnapshot) {
+      return <div style={{ color: "#9ca3af" }}>Waiting for referee…</div>;
+    }
+    const p1Name = match?.players[0]?.codename ?? "P1";
+    const p2Name = match?.players[1]?.codename ?? "P2";
+    const p1Top = latestSnapshot.p1.y - PLAYER_HALF_HEIGHT;
+    const p2Top = latestSnapshot.p2.y - PLAYER_HALF_HEIGHT;
+    const p1Left = latestSnapshot.p1.x - PLAYER_HALF_WIDTH;
+    const p2Left = latestSnapshot.p2.x - PLAYER_HALF_WIDTH;
+    return (
+      <>
+        <div
+          style={{
+            position: "absolute",
+            left: `${p1Left}px`,
+            top: `${p1Top}px`,
+            width: `${PLAYER_WIDTH}px`,
+            height: `${PLAYER_HEIGHT}px`,
+            background: slot === 1 ? "#38bdf8" : "#3b82f6",
+            borderRadius: "4px",
+            transition: "transform 0.05s linear",
+          }}
+          title={`${p1Name} HP: ${latestSnapshot.p1.hp}`}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `${p2Left}px`,
+            top: `${p2Top}px`,
+            width: `${PLAYER_WIDTH}px`,
+            height: `${PLAYER_HEIGHT}px`,
+            background: slot === 2 ? "#38bdf8" : "#f97316",
+            borderRadius: "4px",
+            transition: "transform 0.05s linear",
+          }}
+          title={`${p2Name} HP: ${latestSnapshot.p2.hp}`}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: "16px",
+            top: "16px",
+            color: "#e5e7eb",
+            fontSize: "14px",
+            textShadow: "0 1px 2px rgba(0,0,0,0.6)",
+          }}
+        >
+          <div>{p1Name}: {latestSnapshot.p1.hp} HP</div>
+          <div>{p2Name}: {latestSnapshot.p2.hp} HP</div>
+          {latestSnapshot.events?.map((event, idx) => (
+            <div key={idx} style={{ color: "#f87171" }}>{event}</div>
+          ))}
+        </div>
+      </>
+    );
+  };
+
+  const handleExit = () => {
+    navigate("/");
+  };
+
   return (
-    <main>
-      <section className="card">
+    <main style={{ minHeight: "100vh", background: "#0f1115", color: "#e5e7eb" }}>
+      <div style={{ padding: "16px" }}>
+        <Link to="/" style={{ color: "#7dd3fc", textDecoration: "none" }}>
+          ← Lobby
+        </Link>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "8px" }}>
+          <h1 style={{ margin: 0 }}>{arena?.name ?? "Arena"}</h1>
+          <button
+            type="button"
+            onClick={handleExit}
+            style={{
+              background: "#ef4444",
+              color: "#fff",
+              border: "none",
+              padding: "8px 12px",
+              borderRadius: "6px",
+              cursor: "pointer",
+            }}
+          >
+            Exit Arena
+          </button>
+        </div>
+        {arena?.description ? <p style={{ color: "#9ca3af" }}>{arena.description}</p> : null}
+        {statusRibbon}
+        {waitingNotice}
+        {!player ? (
+          <div style={{ color: "#f87171", marginBottom: "12px" }}>
+            Login to control a fighter.
+          </div>
+        ) : null}
         {error ? (
-          <>
-            <h1>Arena Error</h1>
-            <p>{error}</p>
-          </>
-        ) : arena ? (
-          <>
-            <h1>{arena.name}</h1>
-            <p>{arena.description || "No description yet."}</p>
-            <p>Status: {arena.isActive ? "Active" : "Inactive"}</p>
-            {arena.capacity ? <p>Capacity: {arena.capacity}</p> : null}
-            <p className="muted">
-              Gameplay coming soon. Hang tight while we wire up the battles!
-            </p>
-          </>
-        ) : (
-          <>
-            <h1>Loading arena…</h1>
-            <p>Please wait while we fetch arena details.</p>
-          </>
-        )}
-      </section>
+          <div style={{ color: "#f87171" }}>{error}</div>
+        ) : null}
+        <div
+          style={{
+            position: "relative",
+            width: `${ARENA_WIDTH}px`,
+            height: `${ARENA_HEIGHT}px`,
+            background: "#111827",
+            borderRadius: "12px",
+            border: "1px solid #1f2937",
+            overflow: "hidden",
+            marginTop: "16px",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              bottom: 0,
+              width: "100%",
+              height: "40px",
+              background: "#1f2937",
+            }}
+          />
+          {renderSnapshot()}
+        </div>
+      </div>
     </main>
   );
 };

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -7,7 +7,7 @@ export interface BossProfile {
 export interface PlayerProfile {
   id: string;
   codename: string;
-  passcode: string;
+  passcode?: string;
   preferredArenaId?: string;
   createdAt: string;
   lastActiveAt?: string;
@@ -17,7 +17,7 @@ export interface Arena {
   id: string;
   name: string;
   description?: string;
-  capacity?: number;
+  capacity?: number | null;
   isActive: boolean;
   createdAt: string;
 }

--- a/src/types/netcode.ts
+++ b/src/types/netcode.ts
@@ -1,0 +1,37 @@
+export type InputIntent = {
+  left: boolean;
+  right: boolean;
+  up: boolean;
+  jump: boolean;
+  attack: boolean;
+  ts: number;
+  seq: number;
+};
+
+export type PlayerState = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  hp: number;
+};
+
+export type Snapshot = {
+  t: number;
+  p1: PlayerState;
+  p2: PlayerState;
+  events?: string[];
+  ts: number;
+};
+
+export type MatchStatus = "waiting" | "active" | "ended";
+
+export type MatchDoc = {
+  id: string;
+  arenaId: string;
+  players: { playerId: string; codename: string }[];
+  status: MatchStatus;
+  tick: number;
+  createdAt: string;
+  updatedAt?: string;
+};

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -1,0 +1,26 @@
+import type { MutableRefObject } from "react";
+import type { InputIntent } from "../types/netcode";
+import type { KeyIntentState } from "../game/input/KeyBinder";
+import { nowMs } from "./time";
+
+const FALLBACK_STATE: KeyIntentState = {
+  left: false,
+  right: false,
+  up: false,
+  jump: false,
+  attack: false,
+  seq: 0,
+};
+
+export function sampleKeyboardIntent(keysRef: MutableRefObject<KeyIntentState | null | undefined>): InputIntent {
+  const state = keysRef.current ?? FALLBACK_STATE;
+  return {
+    left: !!state.left,
+    right: !!state.right,
+    up: !!state.up,
+    jump: !!state.jump,
+    attack: !!state.attack,
+    ts: nowMs(),
+    seq: state.seq,
+  };
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,3 @@
+export function nowMs(): number {
+  return Date.now();
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-cat > vite.config.ts <<'TS'
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -14,4 +13,3 @@ export default defineConfig({
   server: { port: 5173 },
   preview: { port: 4173 },
 });
-TS


### PR DESCRIPTION
## Summary
- add shared netcode types plus Firebase helpers for creating matches, recording inputs, and streaming snapshots
- implement referee/client runtime loops with deterministic simulation and keyboard sampling utilities
- wire ArenaPage into the online flow with presence handling, status ribbon, and basic in-browser rendering; open Firestore dev rules for match documents

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdd08756f4832e97d09f5bf9259b01