### PR TITLE
Implement arena multiplayer gameplay

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,40 +1,23 @@
 rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {
-
-    // === DEV RULES (permissive) ===
-    // Anyone with an anonymous session can read/write the core game data.
-    // We will tighten with Cloud Functions + admin claims later.
-
-    // Arenas and per-arena presence (who's inside)
+  match /databases/{db}/documents {
     match /arenas/{arenaId} {
       allow read, write: if request.auth != null; // DEV
       match /presence/{playerId} {
         allow read, write: if request.auth != null; // DEV
       }
+      match /state/{documentId} {
+        allow read, write: if request.auth != null; // DEV
+      }
     }
-
-    // Players (name, stats, settings)
     match /players/{playerId} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null; // DEV
-    }
-
-    // Passcode mapping (doc id == passcode)
-    match /passcodes/{passcode} {
       allow read, write: if request.auth != null; // DEV
     }
-
-    // Optional: leaderboard mirror (if you create it later)
-    match /leaderboard/{playerId} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null; // DEV
+    match /passcodes/{doc} {
+      allow read, write: if request.auth != null; // DEV
     }
-
-    // Read-only metadata
-    match /meta/{doc} {
-      allow read: if true;
-      allow write: if false;
+    match /leaderboard/{doc} {
+      allow read, write: if request.auth != null; // DEV
     }
   }
 }

--- a/src/game/arena/ArenaScene.ts
+++ b/src/game/arena/ArenaScene.ts
@@ -1,0 +1,283 @@
+import Phaser from "phaser";
+import { createArenaSync, type ArenaStateSnapshot, type ArenaSync } from "../net/arenaSync";
+import { Player } from "../entities/Player";
+import { RemoteOpponent } from "../entities/RemoteOpponent";
+
+const WORLD_WIDTH = 960;
+const WORLD_HEIGHT = 540;
+const GROUND_HEIGHT = 40;
+const DAMAGE_PER_HIT = 10;
+const DAMAGE_DEBOUNCE_MS = 120;
+const RESPAWN_DELAY_MS = 1500;
+
+export interface ArenaSceneConfig {
+  arenaId: string;
+  me: { id: string; codename: string };
+  spawn: { x: number; y: number };
+}
+
+export default class ArenaScene extends Phaser.Scene {
+  private arenaId!: string;
+  private me!: { id: string; codename: string };
+  private spawn!: { x: number; y: number };
+
+  private player?: Player;
+  private opponent?: RemoteOpponent;
+  private ground?: Phaser.GameObjects.Rectangle;
+  private hudText?: Phaser.GameObjects.Text;
+  private oppHudText?: Phaser.GameObjects.Text;
+  private koText?: Phaser.GameObjects.Text;
+  private koTween?: Phaser.Tweens.Tween;
+  private respawnTimer?: Phaser.Time.TimerEvent;
+
+  private sync?: ArenaSync;
+  private unsubscribe?: () => void;
+  private opponentId?: string;
+  private lastHitAt = 0;
+  private controlsLocked = false;
+  private latestOpponentName = "";
+
+  constructor() {
+    super("Arena");
+  }
+
+  init(data: ArenaSceneConfig) {
+    this.arenaId = data.arenaId;
+    this.me = data.me;
+    this.spawn = data.spawn;
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor(0x0f1115);
+    this.physics.world.setBounds(0, 0, WORLD_WIDTH, WORLD_HEIGHT);
+
+    this.createGround();
+
+    this.player = new Player(this, this.spawn.x, this.spawn.y);
+    this.player.healFull();
+
+    this.opponent = new RemoteOpponent(this, this.spawn.x, this.spawn.y);
+
+    if (this.ground && this.player) {
+      this.physics.add.collider(this.player.sprite, this.ground);
+    }
+
+    if (this.player && this.opponent) {
+      this.physics.add.overlap(
+        this.player.attackHitbox,
+        this.opponent.sprite,
+        this.handleAttackOverlap,
+        undefined,
+        this,
+      );
+    }
+
+    this.createHud();
+    this.createKoText();
+
+    this.sync = createArenaSync({ arenaId: this.arenaId, meId: this.me.id });
+    this.unsubscribe = this.sync.subscribe(this.handleArenaState);
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.handleShutdown, this);
+    this.events.once(Phaser.Scenes.Events.DESTROY, this.handleShutdown, this);
+  }
+
+  update(_: number, delta: number) {
+    const dt = delta / 1000;
+    if (!this.player) return;
+
+    this.player.update(dt);
+
+    const body = this.player.body;
+    const facing = this.player.facing === 1 ? "R" : "L";
+    this.sync?.updateLocalState({
+      codename: this.me.codename,
+      x: this.player.sprite.x,
+      y: this.player.sprite.y,
+      vx: body.velocity.x,
+      vy: body.velocity.y,
+      facing,
+      anim: this.player.isAttackActive() ? "attack" : undefined,
+      hp: this.player.hp,
+    });
+  }
+
+  private handleAttackOverlap = () => {
+    if (!this.player || !this.opponentId || !this.opponent) return;
+    if (!this.player.isAttackActive()) return;
+    if (!this.player.registerHit()) return;
+
+    const now = this.time.now;
+    if (now - this.lastHitAt < DAMAGE_DEBOUNCE_MS) {
+      return;
+    }
+    this.lastHitAt = now;
+
+    this.sync?.applyDamage(this.opponentId, DAMAGE_PER_HIT).catch((err) => {
+      console.warn("[ArenaScene] failed to apply damage", err);
+    });
+  };
+
+  private handleArenaState = (state?: ArenaStateSnapshot) => {
+    const players = state?.players ?? {};
+    const meState = players?.[this.me.id];
+
+    if (meState && this.player) {
+      const hp = typeof meState.hp === "number" ? meState.hp : this.player.hp;
+      const prevHp = this.player.hp;
+      this.player.setHp(hp);
+      if (prevHp > 0 && hp <= 0) {
+        this.onLocalKo();
+      }
+      this.updateHud();
+    }
+
+    const otherIds = Object.keys(players ?? {}).filter((id) => id !== this.me.id);
+    otherIds.sort();
+    const targetOpponentId = otherIds[0];
+
+    if (!targetOpponentId) {
+      this.opponentId = undefined;
+      this.opponent?.setActive(false);
+      this.latestOpponentName = "";
+      this.updateHud();
+      return;
+    }
+
+    const opponentState = players?.[targetOpponentId];
+    if (!opponentState) return;
+
+    if (this.opponentId !== targetOpponentId) {
+      this.opponentId = targetOpponentId;
+      this.opponent?.setCodename(opponentState.codename ?? "Agent");
+      this.lastHitAt = 0;
+    }
+
+    const oppHp = typeof opponentState.hp === "number" ? opponentState.hp : this.opponent?.hp ?? 100;
+    const prevOppHp = this.opponent?.hp ?? oppHp;
+    this.opponent?.setState({
+      x: opponentState.x ?? this.spawn.x,
+      y: opponentState.y ?? this.spawn.y,
+      facing: opponentState.facing === "L" ? "L" : "R",
+      hp: oppHp,
+    });
+
+    if (prevOppHp > 0 && oppHp <= 0) {
+      this.flashKo();
+    }
+
+    this.latestOpponentName = opponentState.codename ?? "Agent";
+    this.updateHud();
+  };
+
+  private onLocalKo() {
+    if (!this.player || this.controlsLocked) return;
+    this.controlsLocked = true;
+    this.player.setControlsEnabled(false);
+    this.flashKo();
+
+    this.respawnTimer?.remove(false);
+    this.respawnTimer = this.time.delayedCall(RESPAWN_DELAY_MS, () => {
+      if (!this.player) return;
+      this.sync?.respawn(this.spawn).catch((err) => console.warn("[ArenaScene] respawn failed", err));
+      this.player.setPosition(this.spawn.x, this.spawn.y);
+      this.player.setHp(100);
+      this.player.setControlsEnabled(true);
+      this.controlsLocked = false;
+      this.lastHitAt = 0;
+      this.updateHud();
+    });
+  }
+
+  private createGround() {
+    const groundY = WORLD_HEIGHT - GROUND_HEIGHT / 2;
+    this.ground = this.add.rectangle(WORLD_WIDTH / 2, groundY, WORLD_WIDTH, GROUND_HEIGHT, 0x1f2937);
+    this.physics.add.existing(this.ground, true);
+    const body = this.ground.body as Phaser.Physics.Arcade.StaticBody;
+    body.updateFromGameObject();
+  }
+
+  private createHud() {
+    this.hudText = this.add.text(20, 16, "", {
+      fontFamily: "monospace",
+      fontSize: "16px",
+      color: "#bfdbfe",
+    });
+    this.hudText.setScrollFactor(0);
+
+    this.oppHudText = this.add.text(20, 40, "", {
+      fontFamily: "monospace",
+      fontSize: "16px",
+      color: "#fca5a5",
+    });
+    this.oppHudText.setScrollFactor(0);
+
+    this.updateHud();
+  }
+
+  private updateHud() {
+    if (!this.hudText) return;
+    const myHp = this.player ? Math.round(this.player.hp) : 0;
+    const opponentHp = this.opponent && this.opponent.sprite.visible ? Math.round(this.opponent.hp) : null;
+
+    this.hudText.setText(`You (${this.me.codename}) HP: ${myHp}`);
+    if (this.oppHudText) {
+      if (opponentHp === null) {
+        this.oppHudText.setText("Waiting for opponent...");
+      } else {
+        const name = this.latestOpponentName || "Opponent";
+        this.oppHudText.setText(`${name} HP: ${opponentHp}`);
+      }
+    }
+  }
+
+  private createKoText() {
+    this.koText = this.add
+      .text(WORLD_WIDTH / 2, 140, "KO!", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "48px",
+        color: "#f97316",
+        stroke: "#0f1115",
+        strokeThickness: 4,
+      })
+      .setOrigin(0.5)
+      .setAlpha(0);
+    this.koText.setScrollFactor(0);
+  }
+
+  private flashKo() {
+    if (!this.koText) return;
+    this.koTween?.stop();
+    this.koText.setAlpha(1);
+    this.koText.setScale(1);
+    this.koTween = this.tweens.add({
+      targets: this.koText,
+      alpha: 0,
+      scale: 1.3,
+      duration: 400,
+      ease: "Quad.easeOut",
+    });
+  }
+
+  private handleShutdown() {
+    this.koTween?.stop();
+    this.respawnTimer?.remove(false);
+    this.respawnTimer = undefined;
+    this.player?.destroy();
+    this.player = undefined;
+    this.opponent?.destroy();
+    this.opponent = undefined;
+    this.hudText?.destroy();
+    this.hudText = undefined;
+    this.oppHudText?.destroy();
+    this.oppHudText = undefined;
+    this.ground?.destroy();
+    this.ground = undefined;
+    this.koText?.destroy();
+    this.koText = undefined;
+    this.sync?.destroy();
+    this.sync = undefined;
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
+}

--- a/src/game/entities/RemoteOpponent.ts
+++ b/src/game/entities/RemoteOpponent.ts
@@ -1,0 +1,74 @@
+import Phaser from "phaser";
+
+const OPPONENT_WIDTH = 28;
+const OPPONENT_HEIGHT = 48;
+const OPPONENT_COLOR = 0xf87171;
+
+export class RemoteOpponent {
+  readonly maxHp = 100;
+  hp = this.maxHp;
+  codename = "Agent";
+
+  readonly sprite: Phaser.GameObjects.Rectangle;
+  readonly body: Phaser.Physics.Arcade.Body;
+  private readonly nameTag: Phaser.GameObjects.Text;
+
+  constructor(private scene: Phaser.Scene, x: number, y: number) {
+    this.sprite = scene.add.rectangle(x, y, OPPONENT_WIDTH, OPPONENT_HEIGHT, OPPONENT_COLOR);
+    scene.physics.add.existing(this.sprite);
+    this.body = this.sprite.body as Phaser.Physics.Arcade.Body;
+    this.body.setAllowGravity(false);
+    this.body.setImmovable(true);
+    this.body.setSize(OPPONENT_WIDTH, OPPONENT_HEIGHT, true);
+
+    this.nameTag = scene.add.text(x, y - OPPONENT_HEIGHT / 2 - 18, this.codename, {
+      fontFamily: "system-ui, sans-serif",
+      fontSize: "14px",
+      color: "#fca5a5",
+      stroke: "#0f1115",
+      strokeThickness: 2,
+    });
+    this.nameTag.setOrigin(0.5);
+    this.nameTag.setScrollFactor(1);
+    this.nameTag.setDepth(10);
+
+    this.sprite.setDepth(5);
+
+    this.setActive(false);
+  }
+
+  setActive(active: boolean) {
+    this.sprite.setVisible(active);
+    this.nameTag.setVisible(active);
+    this.body.enable = active;
+  }
+
+  setCodename(name: string | undefined) {
+    if (!name) return;
+    this.codename = name;
+    this.nameTag.setText(name);
+  }
+
+  setState(state: { x: number; y: number; facing?: "L" | "R"; hp?: number }) {
+    const { x, y } = state;
+    this.sprite.setPosition(x, y);
+    this.body.reset(x, y);
+    this.nameTag.setPosition(x, y - OPPONENT_HEIGHT / 2 - 18);
+
+    const facing = state.facing === "L" ? -1 : 1;
+    this.sprite.setScale(facing, 1);
+
+    if (typeof state.hp === "number") {
+      this.hp = Phaser.Math.Clamp(state.hp, 0, this.maxHp);
+    }
+
+    if (!this.sprite.visible) {
+      this.setActive(true);
+    }
+  }
+
+  destroy() {
+    this.sprite.destroy();
+    this.nameTag.destroy();
+  }
+}

--- a/src/game/net/arenaSync.ts
+++ b/src/game/net/arenaSync.ts
@@ -1,0 +1,117 @@
+import { applyDamage, respawnPlayer, updateArenaPlayerState, watchArenaState, type ArenaPlayerState } from "../../firebase";
+
+export type ArenaStateSnapshot = {
+  tick?: number;
+  lastUpdate?: unknown;
+  players?: Record<string, (ArenaPlayerState & { updatedAt?: unknown }) | undefined>;
+};
+
+export interface ArenaSyncOptions {
+  arenaId: string;
+  meId: string;
+  throttleMs?: number;
+}
+
+export interface ArenaSync {
+  updateLocalState(partial: Partial<ArenaPlayerState>): void;
+  subscribe(cb: (state: ArenaStateSnapshot | undefined) => void): () => void;
+  applyDamage(targetPlayerId: string, amount: number): Promise<void>;
+  respawn(spawn: { x: number; y: number }): Promise<void>;
+  destroy(): void;
+}
+
+export function createArenaSync(options: ArenaSyncOptions): ArenaSync {
+  const { arenaId, meId, throttleMs = 50 } = options;
+  const listeners = new Set<(state: ArenaStateSnapshot | undefined) => void>();
+
+  let queued: Partial<ArenaPlayerState> | null = null;
+  let lastSent = 0;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribe: (() => void) | null = null;
+  let destroyed = false;
+
+  const flush = () => {
+    if (!queued) return;
+    const payload = queued;
+    queued = null;
+    lastSent = Date.now();
+    updateArenaPlayerState(arenaId, meId, payload).catch((err) => {
+      console.warn("[arenaSync] failed to update player state", err);
+    });
+  };
+
+  const scheduleFlush = () => {
+    if (destroyed) return;
+    const now = Date.now();
+    const elapsed = now - lastSent;
+    const delay = Math.max(0, throttleMs - elapsed);
+    if (delay === 0) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      flush();
+      return;
+    }
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timeout = null;
+      flush();
+    }, delay);
+  };
+
+  const ensureSubscription = () => {
+    if (unsubscribe) return;
+    unsubscribe = watchArenaState(arenaId, (state) => {
+      listeners.forEach((listener) => {
+        try {
+          listener(state as ArenaStateSnapshot | undefined);
+        } catch (err) {
+          console.warn("[arenaSync] listener error", err);
+        }
+      });
+    });
+  };
+
+  return {
+    updateLocalState(partial: Partial<ArenaPlayerState>) {
+      if (destroyed) return;
+      queued = { ...(queued ?? {}), ...partial };
+      scheduleFlush();
+    },
+    subscribe(cb) {
+      if (destroyed) return () => undefined;
+      listeners.add(cb);
+      ensureSubscription();
+      return () => {
+        listeners.delete(cb);
+        if (listeners.size === 0 && unsubscribe) {
+          unsubscribe();
+          unsubscribe = null;
+        }
+      };
+    },
+    applyDamage(targetPlayerId: string, amount: number) {
+      return applyDamage(arenaId, targetPlayerId, amount);
+    },
+    respawn(spawn) {
+      return respawnPlayer(arenaId, meId, spawn);
+    },
+    destroy() {
+      destroyed = true;
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      if (unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
+      listeners.clear();
+      queued = null;
+    },
+  };
+}

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -1,14 +1,23 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import Phaser from "phaser";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   ensureAnonAuth,
   getArena,
+  initArenaPlayerState,
   joinArena,
   leaveArena,
   watchArenaPresence,
 } from "../firebase";
 import { useAuth } from "../context/AuthContext";
 import type { Arena, ArenaPresenceEntry } from "../types/models";
+import { makeGame } from "../game/phaserGame";
+import ArenaScene from "../game/arena/ArenaScene";
+
+const CANVAS_WIDTH = 960;
+const CANVAS_HEIGHT = 540;
+const SPAWN_A = { x: 240, y: 360 } as const;
+const SPAWN_B = { x: 720, y: 360 } as const;
 
 const ArenaPage: React.FC = () => {
   const { arenaId } = useParams<{ arenaId: string }>();
@@ -133,12 +142,135 @@ const ArenaPage: React.FC = () => {
         <div style={{ padding: "16px", color: "#fca5a5" }}>{error}</div>
       ) : null}
 
-      <main style={{ padding: "32px", textAlign: "center" }}>
-        <h2>Multiplayer combat coming soon</h2>
-        <p>Stay frosty, Agent. For now, use the training mode to hone your skills.</p>
+      <main style={{ padding: "16px" }}>
+        {player && arenaId ? (
+          <ArenaCanvas arenaId={arenaId} me={{ id: player.id, codename: player.codename }} presence={playersInArena} />
+        ) : (
+          <div style={{ padding: "24px", textAlign: "center" }}>Loading arena...</div>
+        )}
       </main>
     </div>
   );
 };
 
 export default ArenaPage;
+
+interface ArenaCanvasProps {
+  arenaId: string;
+  me: { id: string; codename: string };
+  presence: ArenaPresenceEntry[];
+}
+
+const ArenaCanvas: React.FC<ArenaCanvasProps> = ({ arenaId, me, presence }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const initKeyRef = useRef<string | null>(null);
+  const [stateReady, setStateReady] = useState(false);
+
+  const spawn = useMemo(() => {
+    const ids = presence.map((p) => p.playerId);
+    if (!ids.includes(me.id)) {
+      ids.push(me.id);
+    }
+    ids.sort();
+    const index = ids.indexOf(me.id);
+    if (index <= 0) return SPAWN_A;
+    if (index === 1) return SPAWN_B;
+    return index % 2 === 0 ? SPAWN_A : SPAWN_B;
+  }, [presence, me.id]);
+
+  useEffect(() => {
+    if (!spawn) return;
+    const key = `${arenaId}:${me.id}:${me.codename}`;
+    if (initKeyRef.current === key) {
+      return;
+    }
+    let cancelled = false;
+    initKeyRef.current = key;
+    setStateReady(false);
+    (async () => {
+      try {
+        await initArenaPlayerState(arenaId, { id: me.id, codename: me.codename }, spawn);
+        if (!cancelled) {
+          setStateReady(true);
+        }
+      } catch (err) {
+        console.warn("[ArenaCanvas] initArenaPlayerState failed", err);
+        if (!cancelled) {
+          initKeyRef.current = null;
+          setStateReady(false);
+        }
+      }
+    })().catch((err) => console.error(err));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [arenaId, me.id, me.codename, spawn]);
+
+  useEffect(() => {
+    if (!stateReady) return;
+    if (!containerRef.current) return;
+    if (gameRef.current) return;
+
+    const config: Phaser.Types.Core.GameConfig = {
+      type: Phaser.AUTO,
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+      parent: containerRef.current,
+      backgroundColor: "#0f1115",
+      physics: { default: "arcade", arcade: { gravity: { x: 0, y: 900 }, debug: false } },
+      scene: [],
+    };
+
+    const game = makeGame(config);
+    gameRef.current = game;
+    const sceneData = { arenaId, me: { id: me.id, codename: me.codename }, spawn };
+    game.scene.add("Arena", ArenaScene, true, sceneData);
+
+    return () => {
+      gameRef.current?.destroy(true);
+      gameRef.current = null;
+    };
+  }, [arenaId, me.id, me.codename, spawn, stateReady]);
+
+  useEffect(() => {
+    return () => {
+      gameRef.current?.destroy(true);
+      gameRef.current = null;
+    };
+  }, []);
+
+  const gameReady = stateReady && !!gameRef.current;
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center" }}>
+      <div
+        ref={containerRef}
+        style={{
+          width: CANVAS_WIDTH,
+          height: CANVAS_HEIGHT,
+          background: "#0f1115",
+          border: "1px solid #1f2937",
+          position: "relative",
+        }}
+      >
+        {!gameReady ? (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#9ca3af",
+              fontSize: 16,
+            }}
+          >
+            Initializing arena...
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- relax Firestore dev rules to cover arena state documents and add helpers for initializing, updating, and mutating shared arena player data
- add Phaser arena gameplay scene with remote opponent rendering, shared HP handling, KO/respawn flow, and a network sync throttle
- update the arena page to initialize state, pick deterministic spawns, and launch the arena scene inside the lobby UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceec468bb8832eb650cd3aecb1fdd8