### PR TITLE
Add deterministic sim reducer and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode
 .idea
 dist
+dist-tests

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "clean:vite": "rm -rf node_modules/.vite || true",
-    "lint": "echo \"(optional) add eslint later\""
+    "lint": "echo \"(optional) add eslint later\"",
+    "typecheck": "tsc --noEmit",
+    "test:build": "tsc --project tsconfig.tests.json",
+    "test:run": "node --test dist-tests/**/*.spec.js",
+    "test": "pnpm run test:build && pnpm run test:run"
   },
   "dependencies": {
     "firebase": "^10.12.2",

--- a/src/sim/__tests__/reducer.spec.ts
+++ b/src/sim/__tests__/reducer.spec.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyActions, getSnapshot, initSim } from '../reducer.js';
+import type { ActionDoc } from '../types.js';
+
+const STEP_MS = 16.6667;
+
+function action(playerId: string, input: ActionDoc['input'], seq = 0): ActionDoc {
+  return {
+    arenaId: 'arena',
+    playerId,
+    seq,
+    input,
+    clientTs: 0,
+  };
+}
+
+test('initSim spawns players with deterministic defaults', () => {
+  const sim = initSim({ seed: 42, myPlayerId: 'p1', opponentId: 'p2' });
+  const snap = getSnapshot(sim);
+  assert.equal(snap.tick, 0);
+  assert.equal(snap.tMs, 0);
+  assert.deepEqual(snap.players['p1'].pos, { x: 200, y: 0 });
+  assert.deepEqual(snap.players['p2'].pos, { x: 760, y: 0 });
+  assert.equal(snap.players['p1'].hp, 100);
+  assert.equal(snap.players['p2'].hp, 100);
+});
+
+test('holding right accelerates the player forward', () => {
+  const sim = initSim({ seed: 1, myPlayerId: 'me', opponentId: 'op' });
+  applyActions(sim, [action('me', { right: true })], 100);
+  const snap = getSnapshot(sim);
+  assert.ok(snap.players['me'].pos.x > 200);
+  assert.equal(snap.players['me'].dir, 1);
+});
+
+test('jump is edge triggered and single use while airborne', () => {
+  const sim = initSim({ seed: 1, myPlayerId: 'me', opponentId: 'op' });
+  applyActions(sim, [action('me', { jump: true })], STEP_MS);
+  let snap = getSnapshot(sim);
+  const firstVy = snap.players['me'].vel.y;
+  assert.ok(firstVy > 0);
+
+  applyActions(sim, [action('me', { jump: false })], STEP_MS);
+  snap = getSnapshot(sim);
+  assert.ok(snap.players['me'].pos.y > 0);
+
+  applyActions(sim, [action('me', { jump: true })], STEP_MS);
+  snap = getSnapshot(sim);
+  assert.ok(snap.players['me'].vel.y <= firstVy);
+});
+
+test('attack damages once per window within the arc', () => {
+  const sim = initSim({ seed: 1, myPlayerId: 'a', opponentId: 'b' });
+  const attacker = sim.snap.players['a'];
+  const defender = sim.snap.players['b'];
+  attacker.pos.x = 300;
+  defender.pos.x = 330;
+  attacker.dir = 1;
+  defender.dir = -1;
+
+  applyActions(sim, [action('a', { attack: true })], STEP_MS);
+  let snap = getSnapshot(sim);
+  assert.equal(snap.players['b'].hp, 90);
+
+  applyActions(sim, [], STEP_MS);
+  snap = getSnapshot(sim);
+  assert.equal(snap.players['b'].hp, 90);
+});
+
+test("positions clamp to bounds and players ground at the floor", () => {
+  const sim = initSim({ seed: 1, myPlayerId: "me", opponentId: "op" });
+  const player = sim.snap.players["me"];
+  player.pos.x = -75;
+  player.vel.x = -200;
+
+  applyActions(sim, [], STEP_MS);
+  let snap = getSnapshot(sim);
+  assert.equal(snap.players["me"].pos.x, 0);
+
+  player.pos.y = 150;
+  player.vel.y = -100;
+  player.grounded = false;
+
+  applyActions(sim, [], 500);
+  snap = getSnapshot(sim);
+  assert.equal(snap.players["me"].pos.y, 0);
+  assert.equal(snap.players["me"].grounded, true);
+});

--- a/src/sim/reducer.ts
+++ b/src/sim/reducer.ts
@@ -1,0 +1,301 @@
+import type {
+  ActionDoc,
+  InputFlags,
+  PlayerId,
+  PlayerState,
+  Sim,
+  Snapshot,
+  Vec2,
+} from './types.js';
+
+const FIXED_DT_MS = 16.6667;
+const GRAVITY = 900;
+const ACCEL = 1200;
+const FRICTION_G = 1400;
+const FRICTION_A = 200;
+const JUMP = 420;
+const ATTACK_WINDOW_MS = 120;
+const ATTACK_COOLDOWN_MS = 250;
+const DAMAGE = 10;
+const ARENA_MIN_X = 0;
+const ARENA_MAX_X = 960;
+const FLOOR_Y = 0;
+const TIME_PRECISION = 1e-4;
+
+const PLAYER_SPAWN_POSITIONS: Record<'left' | 'right', Vec2> = {
+  left: { x: 200, y: 0 },
+  right: { x: 760, y: 0 },
+};
+
+const PLAYER_INITIAL_HP = 100;
+
+interface InternalSim extends Sim {
+  _inputs: Record<PlayerId, InputFlags>;
+  _prevJump: Record<PlayerId, boolean>;
+  _prevAttack: Record<PlayerId, boolean>;
+  _attackSeq: Record<PlayerId, number>;
+  _currentAttackId: Record<PlayerId, number | null>;
+  _attackHitToken: Record<PlayerId, number | null>;
+  _accumulator: number;
+}
+
+const EPSILON = 1e-6;
+
+function clampTime(value: number): number {
+  return Math.round(value / TIME_PRECISION) * TIME_PRECISION;
+}
+
+function clonePlayerState(state: PlayerState): PlayerState {
+  return {
+    pos: { ...state.pos },
+    vel: { ...state.vel },
+    dir: state.dir,
+    hp: state.hp,
+    attackActiveUntil: state.attackActiveUntil,
+    canAttackAt: state.canAttackAt,
+    grounded: state.grounded,
+  };
+}
+
+function ensureInternal(sim: Sim): InternalSim {
+  const internal = sim as InternalSim;
+  if (!internal._inputs) {
+    internal._inputs = {};
+  }
+  if (!internal._prevJump) {
+    internal._prevJump = {};
+  }
+  if (!internal._prevAttack) {
+    internal._prevAttack = {};
+  }
+  if (!internal._attackSeq) {
+    internal._attackSeq = {};
+  }
+  if (!internal._currentAttackId) {
+    internal._currentAttackId = {};
+  }
+  if (!internal._attackHitToken) {
+    internal._attackHitToken = {};
+  }
+  if (typeof internal._accumulator !== 'number') {
+    internal._accumulator = 0;
+  }
+  return internal;
+}
+
+function createPlayerState(position: Vec2, dir: -1 | 1): PlayerState {
+  return {
+    pos: { ...position },
+    vel: { x: 0, y: 0 },
+    dir,
+    hp: PLAYER_INITIAL_HP,
+    attackActiveUntil: 0,
+    canAttackAt: 0,
+    grounded: true,
+  };
+}
+
+function applyFriction(state: PlayerState, dtSec: number): void {
+  const friction = (state.grounded ? FRICTION_G : FRICTION_A) * dtSec;
+  if (state.vel.x > 0) {
+    state.vel.x = Math.max(0, state.vel.x - friction);
+  } else if (state.vel.x < 0) {
+    state.vel.x = Math.min(0, state.vel.x + friction);
+  }
+}
+
+function updateAttackState(
+  internal: InternalSim,
+  playerId: PlayerId,
+  state: PlayerState,
+  attackPressed: boolean,
+  prevAttack: boolean,
+  timeMs: number,
+): void {
+  if (attackPressed && !prevAttack && timeMs >= state.canAttackAt) {
+    const nextId = (internal._attackSeq[playerId] ?? 0) + 1;
+    internal._attackSeq[playerId] = nextId;
+    internal._currentAttackId[playerId] = nextId;
+    internal._attackHitToken[playerId] = null;
+    state.attackActiveUntil = clampTime(timeMs + ATTACK_WINDOW_MS);
+    state.canAttackAt = clampTime(timeMs + ATTACK_COOLDOWN_MS);
+  } else if (timeMs >= state.attackActiveUntil) {
+    internal._currentAttackId[playerId] = null;
+  }
+}
+
+function handleAttacks(internal: InternalSim, timeMs: number): void {
+  const ids = Object.keys(internal.snap.players);
+  for (const attackerId of ids) {
+    const attackId = internal._currentAttackId[attackerId];
+    const attacker = internal.snap.players[attackerId];
+    if (!attackId || timeMs >= attacker.attackActiveUntil) {
+      continue;
+    }
+    for (const defenderId of ids) {
+      if (defenderId === attackerId) {
+        continue;
+      }
+      if (internal._attackHitToken[attackerId] === attackId) {
+        break;
+      }
+      const defender = internal.snap.players[defenderId];
+      const dx = defender.pos.x - attacker.pos.x;
+      const dy = defender.pos.y - attacker.pos.y;
+      if (Math.abs(dx) > 40 || Math.abs(dy) > 24) {
+        continue;
+      }
+      if ((attacker.dir === 1 && dx < 0) || (attacker.dir === -1 && dx > 0)) {
+        continue;
+      }
+      defender.hp = Math.max(0, defender.hp - DAMAGE);
+      internal._attackHitToken[attackerId] = attackId;
+      break;
+    }
+  }
+}
+
+function stepSim(internal: InternalSim): void {
+  const dtMs = FIXED_DT_MS;
+  const dtSec = dtMs / 1000;
+  const timeStart = internal.snap.tMs;
+  const playerIds: PlayerId[] = [internal.myId, internal.oppId];
+
+  for (const playerId of playerIds) {
+    const state = internal.snap.players[playerId];
+    if (!state) {
+      continue;
+    }
+    const input = internal._inputs[playerId] ?? {};
+    const left = !!input.left;
+    const right = !!input.right;
+    const jumpPressed = !!input.jump;
+    const attackPressed = !!input.attack;
+    const prevJump = internal._prevJump[playerId] ?? false;
+    const prevAttack = internal._prevAttack[playerId] ?? false;
+
+    updateAttackState(internal, playerId, state, attackPressed, prevAttack, timeStart);
+
+    if (left && !right) {
+      state.vel.x -= ACCEL * dtSec;
+      state.dir = -1;
+    } else if (right && !left) {
+      state.vel.x += ACCEL * dtSec;
+      state.dir = 1;
+    } else {
+      applyFriction(state, dtSec);
+    }
+
+    if (jumpPressed && !prevJump && state.grounded) {
+      state.vel.y = JUMP;
+      state.grounded = false;
+    }
+
+    state.vel.y -= GRAVITY * dtSec;
+
+    state.pos.x += state.vel.x * dtSec;
+    state.pos.y += state.vel.y * dtSec;
+
+    if (state.pos.x < ARENA_MIN_X) {
+      state.pos.x = ARENA_MIN_X;
+      if (state.vel.x < 0) {
+        state.vel.x = 0;
+      }
+    } else if (state.pos.x > ARENA_MAX_X) {
+      state.pos.x = ARENA_MAX_X;
+      if (state.vel.x > 0) {
+        state.vel.x = 0;
+      }
+    }
+
+    if (state.pos.y <= FLOOR_Y) {
+      state.pos.y = FLOOR_Y;
+      if (state.vel.y < 0) {
+        state.vel.y = 0;
+      }
+      state.grounded = true;
+    } else {
+      state.grounded = false;
+    }
+
+    internal._prevJump[playerId] = jumpPressed;
+    internal._prevAttack[playerId] = attackPressed;
+  }
+
+  handleAttacks(internal, timeStart);
+
+  internal.snap.tick += 1;
+  internal.snap.tMs = clampTime(internal.snap.tick * FIXED_DT_MS);
+}
+
+export function initSim(params: { seed: number; myPlayerId: string; opponentId: string }): Sim {
+  const leftId = params.myPlayerId;
+  const rightId = params.opponentId;
+  const players: Record<PlayerId, PlayerState> = {
+    [leftId]: createPlayerState(PLAYER_SPAWN_POSITIONS.left, 1),
+    [rightId]: createPlayerState(PLAYER_SPAWN_POSITIONS.right, -1),
+  };
+
+  const sim: Sim = {
+    myId: leftId,
+    oppId: rightId,
+    seed: params.seed,
+    snap: {
+      tick: 0,
+      tMs: 0,
+      players,
+    },
+  };
+
+  const internal = ensureInternal(sim);
+  internal._inputs[leftId] = {};
+  internal._inputs[rightId] = {};
+  internal._prevJump[leftId] = false;
+  internal._prevJump[rightId] = false;
+  internal._prevAttack[leftId] = false;
+  internal._prevAttack[rightId] = false;
+  internal._attackSeq[leftId] = 0;
+  internal._attackSeq[rightId] = 0;
+  internal._currentAttackId[leftId] = null;
+  internal._currentAttackId[rightId] = null;
+  internal._attackHitToken[leftId] = null;
+  internal._attackHitToken[rightId] = null;
+  internal._accumulator = 0;
+
+  return sim;
+}
+
+export function applyActions(sim: Sim, actions: ActionDoc[], dtMs: number): void {
+  const internal = ensureInternal(sim);
+  const relevantActions = actions.filter((action) => action.playerId in internal.snap.players);
+  relevantActions.sort((a, b) => a.seq - b.seq);
+
+  for (const action of relevantActions) {
+    const previous = internal._inputs[action.playerId] ?? {};
+    internal._inputs[action.playerId] = { ...previous, ...action.input };
+  }
+
+  internal._accumulator += dtMs;
+
+  while (internal._accumulator + EPSILON >= FIXED_DT_MS) {
+    internal._accumulator -= FIXED_DT_MS;
+    stepSim(internal);
+  }
+}
+
+export function getSnapshot(sim: Sim): Snapshot {
+  const players: Record<PlayerId, PlayerState> = {};
+  for (const [playerId, state] of Object.entries(sim.snap.players)) {
+    players[playerId as PlayerId] = clonePlayerState(state);
+  }
+  return {
+    tick: sim.snap.tick,
+    tMs: sim.snap.tMs,
+    players,
+  };
+}
+
+export function rewindTo(_sim: Sim, _tick: number): void {
+  // no-op placeholder for future rollback support
+}
+

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1,0 +1,42 @@
+export type PlayerId = string;
+
+export type InputFlags = {
+  left?: boolean;
+  right?: boolean;
+  jump?: boolean;
+  attack?: boolean;
+};
+
+export type ActionDoc = {
+  arenaId: string;
+  playerId: PlayerId;
+  seq: number;
+  input: InputFlags;
+  clientTs: number;
+  createdAt?: unknown;
+};
+
+export type Vec2 = { x: number; y: number };
+
+export type PlayerState = {
+  pos: Vec2;
+  vel: Vec2;
+  dir: -1 | 1;
+  hp: number;
+  attackActiveUntil: number;
+  canAttackAt: number;
+  grounded: boolean;
+};
+
+export type Snapshot = {
+  tick: number;
+  tMs: number;
+  players: Record<PlayerId, PlayerState>;
+};
+
+export type Sim = {
+  myId: PlayerId;
+  oppId: PlayerId;
+  seed: number;
+  snap: Snapshot;
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,31 @@
+declare module 'node:test' {
+  export interface TestContext {
+    skip(message?: string): void;
+    diagnostic(message: string): void;
+  }
+
+  export type TestFn = (t?: TestContext) => Promise<void> | void;
+
+  export function test(name: string, fn: TestFn): void;
+  export function describe(name: string, fn: () => void): void;
+  export function beforeEach(fn: TestFn): void;
+  export function afterEach(fn: TestFn): void;
+}
+
+declare module 'node:assert/strict' {
+  export function equal(actual: unknown, expected: unknown, message?: string): void;
+  export function deepEqual(actual: unknown, expected: unknown, message?: string): void;
+  export function ok(value: unknown, message?: string): void;
+  export function strictEqual(actual: unknown, expected: unknown, message?: string): void;
+  export function notStrictEqual(actual: unknown, expected: unknown, message?: string): void;
+
+  const assert: {
+    equal: typeof equal;
+    deepEqual: typeof deepEqual;
+    ok: typeof ok;
+    strictEqual: typeof strictEqual;
+    notStrictEqual: typeof notStrictEqual;
+  };
+
+  export default assert;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "noEmit": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["vite/client"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-tests",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["vite/client"],
+    "sourceMap": false
+  },
+  "include": [
+    "src/types.d.ts",
+    "src/sim/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add simulation types and reducer that step deterministic physics/combat snapshots
- provide node-based unit tests covering initialization, movement, jumping, attacking, and clamping
- wire up pnpm scripts and TypeScript config to run the reducer tests via node --test

## Testing
- pnpm typecheck
- pnpm build
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cf11c87954832ebdf8342bc1e7afb5