### PR TITLE
Ensure arena state doc exists and add debug route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import HomePage from "./pages/HomePage";
 import AdminPage from "./pages/AdminPage";
 import ArenaPage from "./pages/ArenaPage";
 import TrainingPage from "./pages/TrainingPage";
+import DebugArenaStatePage from "./pages/DebugArenaStatePage";
 
 export default function App() {
   return (
@@ -17,6 +18,8 @@ export default function App() {
       <Route path="/admin" element={<AdminPage />} />
 
       <Route path="/arena/:arenaId" element={<ArenaPage />} />
+
+      <Route path="/debug/arena/:arenaId" element={<DebugArenaStatePage />} />
 
       {/* the one we need */}
       <Route path="/training" element={<TrainingPage />} />

--- a/src/lib/arenaState.ts
+++ b/src/lib/arenaState.ts
@@ -1,0 +1,16 @@
+import { doc, getDoc, setDoc, serverTimestamp, type DocumentReference } from "firebase/firestore";
+import { db } from "../firebase";
+
+export function arenaStateDoc(arenaId: string) {
+  // Single document at /arenas/{arenaId}/state
+  return doc(db, "arenas", arenaId, "state") as DocumentReference;
+}
+
+export async function ensureArenaState(arenaId: string) {
+  const ref = arenaStateDoc(arenaId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) {
+    await setDoc(ref, { tick: 0, lastUpdate: serverTimestamp(), players: {} }, { merge: true });
+  }
+  return ref;
+}

--- a/src/pages/DebugArenaStatePage.tsx
+++ b/src/pages/DebugArenaStatePage.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react";
+import { collection, onSnapshot, orderBy, query } from "firebase/firestore";
+import { useParams } from "react-router-dom";
+
+import { db } from "../firebase";
+import { arenaStateDoc } from "../lib/arenaState";
+
+interface DebugPresenceEntry {
+  id: string;
+  codename?: string;
+  playerId?: string;
+  authUid?: string;
+  joinedAt?: string;
+  [key: string]: unknown;
+}
+
+const DebugArenaStatePage: React.FC = () => {
+  const { arenaId } = useParams<{ arenaId: string }>();
+  const [presence, setPresence] = useState<DebugPresenceEntry[]>([]);
+  const [presenceError, setPresenceError] = useState<string | null>(null);
+  const [stateData, setStateData] = useState<Record<string, unknown> | null>(null);
+  const [stateError, setStateError] = useState<string | null>(null);
+  const [presenceSnapAt, setPresenceSnapAt] = useState<string | null>(null);
+  const [stateSnapAt, setStateSnapAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!arenaId) {
+      setPresence([]);
+      setPresenceError("Arena ID not provided");
+      return;
+    }
+
+    const presenceQuery = query(
+      collection(db, "arenas", arenaId, "presence"),
+      orderBy("joinedAt", "asc"),
+    );
+
+    const unsubscribe = onSnapshot(
+      presenceQuery,
+      (snapshot) => {
+        const entries: DebugPresenceEntry[] = snapshot.docs.map((docSnap) => ({
+          id: docSnap.id,
+          ...(docSnap.data() as Record<string, unknown>),
+        }));
+        setPresence(entries);
+        setPresenceError(null);
+        setPresenceSnapAt(new Date().toISOString());
+      },
+      (err) => {
+        console.error("[debug/arena] presence subscription error:", err);
+        setPresenceError(err instanceof Error ? err.message : String(err));
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [arenaId]);
+
+  useEffect(() => {
+    if (!arenaId) {
+      setStateData(null);
+      setStateError("Arena ID not provided");
+      return;
+    }
+
+    const ref = arenaStateDoc(arenaId);
+    const unsubscribe = onSnapshot(
+      ref,
+      (snapshot) => {
+        if (snapshot.exists()) {
+          setStateData(snapshot.data() as Record<string, unknown>);
+        } else {
+          setStateData(null);
+        }
+        setStateError(null);
+        setStateSnapAt(new Date().toISOString());
+      },
+      (err) => {
+        console.error("[debug/arena] state subscription error:", err);
+        setStateError(err instanceof Error ? err.message : String(err));
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [arenaId]);
+
+  return (
+    <div style={{ padding: 24, background: "#0f1115", color: "#e5e7eb", minHeight: "100vh" }}>
+      <h1 style={{ marginTop: 0 }}>Arena Debug</h1>
+      <p>
+        Viewing arena <code>{arenaId ?? "(none)"}</code>
+      </p>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2>Presence</h2>
+        <p style={{ color: "#9ca3af" }}>
+          Last snapshot: {presenceSnapAt ? new Date(presenceSnapAt).toLocaleString() : "waiting..."}
+        </p>
+        {presenceError ? (
+          <div style={{ color: "#fca5a5" }}>Error: {presenceError}</div>
+        ) : presence.length === 0 ? (
+          <div style={{ color: "#9ca3af" }}>No presence records.</div>
+        ) : (
+          <ul style={{ listStyle: "disc", paddingLeft: 20 }}>
+            {presence.map((entry) => (
+              <li key={entry.id}>
+                <code>{entry.id}</code>
+                {entry.codename ? ` — ${entry.codename}` : ""}
+                {entry.playerId && entry.playerId !== entry.id ? ` (playerId: ${entry.playerId})` : ""}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2>State document</h2>
+        <p style={{ color: "#9ca3af" }}>
+          Path: <code>{`/arenas/${arenaId ?? "?"}/state`}</code>
+        </p>
+        <p style={{ color: "#9ca3af" }}>
+          Last snapshot: {stateSnapAt ? new Date(stateSnapAt).toLocaleString() : "waiting..."}
+        </p>
+        {stateError ? (
+          <div style={{ color: "#fca5a5" }}>Error: {stateError}</div>
+        ) : (
+          <pre
+            style={{
+              background: "#111827",
+              padding: 16,
+              borderRadius: 8,
+              overflowX: "auto",
+              maxHeight: 360,
+              border: "1px solid #1f2937",
+            }}
+          >
+            {stateData ? JSON.stringify(stateData, null, 2) : "<no data>"}
+          </pre>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default DebugArenaStatePage;


### PR DESCRIPTION
## Summary
- add arena state helpers to ensure the `/arenas/{arenaId}/state` document exists
- update the arena page to initialize the state doc, handle subscription errors, and show descriptive overlays
- add a debug view at `/debug/arena/:arenaId` for presence/state snapshots and wire the route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf39e32c88832e912065e7336c9224