### PR TITLE
Add real-time arenas subscription hook

### DIFF
--- a/src/utils/useArenas.ts
+++ b/src/utils/useArenas.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { collection, onSnapshot, orderBy, query, type FirestoreError } from "firebase/firestore";
+
+import { db } from "../firebase";
+import type { Arena } from "../types/models";
+
+interface UseArenasResult {
+  arenas: Arena[];
+  loading: boolean;
+  error: FirestoreError | null;
+}
+
+export function useArenas(): UseArenasResult {
+  const [arenas, setArenas] = useState<Arena[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<FirestoreError | null>(null);
+
+  useEffect(() => {
+    const arenasQuery = query(collection(db, "arenas"), orderBy("createdAt", "desc"));
+
+    const unsubscribe = onSnapshot(
+      arenasQuery,
+      (snapshot) => {
+        const data = snapshot.docs.map((docSnap) => {
+          const docData = docSnap.data() as any;
+          return {
+            id: docSnap.id,
+            name: docData.name,
+            description: docData.description ?? undefined,
+            capacity: docData.capacity ?? undefined,
+            isActive: !!docData.isActive,
+            createdAt: docData.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
+          } as Arena;
+        });
+        setArenas(data);
+        setLoading(false);
+        setError(null);
+      },
+      (err) => {
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return { arenas, loading, error };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useArenas` hook that subscribes to Firestore arena changes and surfaces loading/error state
- update the admin page to use the hook while keeping existing player management logic intact
- show loading and error feedback for the arenas list so it reflects real-time updates

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf8c086604832ea6020a9b9bf473b6