### PR TITLE
Ensure arenas listener waits for auth

### DIFF
--- a/src/utils/useArenas.ts
+++ b/src/utils/useArenas.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { collection, onSnapshot, orderBy, query, type FirestoreError } from "firebase/firestore";
 
-import { db } from "../firebase";
+import { db, ensureAnonAuth } from "../firebase";
 import type { Arena } from "../types/models";
 
 interface UseArenasResult {
@@ -16,34 +16,56 @@ export function useArenas(): UseArenasResult {
   const [error, setError] = useState<FirestoreError | null>(null);
 
   useEffect(() => {
-    const arenasQuery = query(collection(db, "arenas"), orderBy("createdAt", "desc"));
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
 
-    const unsubscribe = onSnapshot(
-      arenasQuery,
-      (snapshot) => {
-        const data = snapshot.docs.map((docSnap) => {
-          const docData = docSnap.data() as any;
-          return {
-            id: docSnap.id,
-            name: docData.name,
-            description: docData.description ?? undefined,
-            capacity: docData.capacity ?? undefined,
-            isActive: !!docData.isActive,
-            createdAt: docData.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
-          } as Arena;
-        });
-        setArenas(data);
-        setLoading(false);
-        setError(null);
-      },
-      (err) => {
-        setError(err);
-        setLoading(false);
-      },
-    );
+    const setupListener = async () => {
+      try {
+        await ensureAnonAuth();
+        if (cancelled) {
+          return;
+        }
+
+        const arenasQuery = query(collection(db, "arenas"), orderBy("createdAt", "desc"));
+
+        unsubscribe = onSnapshot(
+          arenasQuery,
+          (snapshot) => {
+            const data = snapshot.docs.map((docSnap) => {
+              const docData = docSnap.data() as any;
+              return {
+                id: docSnap.id,
+                name: docData.name,
+                description: docData.description ?? undefined,
+                capacity: docData.capacity ?? undefined,
+                isActive: !!docData.isActive,
+                createdAt: docData.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
+              } as Arena;
+            });
+            setArenas(data);
+            setLoading(false);
+            setError(null);
+          },
+          (err) => {
+            setError(err);
+            setLoading(false);
+          },
+        );
+      } catch (err) {
+        if (!cancelled) {
+          setError(err as FirestoreError);
+          setLoading(false);
+        }
+      }
+    };
+
+    void setupListener();
 
     return () => {
-      unsubscribe();
+      cancelled = true;
+      if (unsubscribe) {
+        unsubscribe();
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure the arenas snapshot listener waits for anonymous authentication before subscribing
- preserve loading and error handling while guarding against running after unmount

## Testing
- npm run typecheck *(fails: existing JSX closing tag errors in src/pages/AdminPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cf92ae9a68832ebb2badd1b213aa54