### PR TITLE
Use useArenas hook for lobby list

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -228,3 +228,23 @@ const AdminPage = () => {
         <h2>Current Arenas</h2>
         {arenasError ? (
           <p>Failed to load arenas.</p>
+        ) : arenasLoading ? (
+          <p>Loading arenas…</p>
+        ) : arenas.length === 0 ? (
+          <p>No arenas created yet.</p>
+        ) : (
+          <ul>
+            {arenas.map((arena) => (
+              <li key={arena.id}>
+                <strong>{arena.name}</strong>
+                {arena.description ? <span className="muted"> — {arena.description}</span> : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default AdminPage;

--- a/src/utils/useArenas.ts
+++ b/src/utils/useArenas.ts
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
-import { collection, onSnapshot, orderBy, query, type FirestoreError } from "firebase/firestore";
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+  type FirestoreError,
+  type Unsubscribe,
+} from "firebase/firestore";
 
-import { db } from "../firebase";
+import { db, ensureAnonAuth } from "../firebase";
 import type { Arena } from "../types/models";
 
 interface UseArenasResult {
@@ -16,34 +23,55 @@ export function useArenas(): UseArenasResult {
   const [error, setError] = useState<FirestoreError | null>(null);
 
   useEffect(() => {
-    const arenasQuery = query(collection(db, "arenas"), orderBy("createdAt", "desc"));
+    let unsubscribe: Unsubscribe | null = null;
+    let isMounted = true;
 
-    const unsubscribe = onSnapshot(
-      arenasQuery,
-      (snapshot) => {
-        const data = snapshot.docs.map((docSnap) => {
-          const docData = docSnap.data() as any;
-          return {
-            id: docSnap.id,
-            name: docData.name,
-            description: docData.description ?? undefined,
-            capacity: docData.capacity ?? undefined,
-            isActive: !!docData.isActive,
-            createdAt: docData.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
-          } as Arena;
-        });
-        setArenas(data);
+    const start = async () => {
+      try {
+        setLoading(true);
+        await ensureAnonAuth();
+        if (!isMounted) return;
+
+        const arenasQuery = query(collection(db, "arenas"), orderBy("createdAt", "desc"));
+
+        unsubscribe = onSnapshot(
+          arenasQuery,
+          (snapshot) => {
+            if (!isMounted) return;
+            const data = snapshot.docs.map((docSnap) => {
+              const docData = docSnap.data() as any;
+              return {
+                id: docSnap.id,
+                name: docData.name,
+                description: docData.description ?? undefined,
+                capacity: docData.capacity ?? undefined,
+                isActive: !!docData.isActive,
+                createdAt:
+                  docData.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
+              } as Arena;
+            });
+            setArenas(data);
+            setLoading(false);
+            setError(null);
+          },
+          (err) => {
+            if (!isMounted) return;
+            setError(err);
+            setLoading(false);
+          },
+        );
+      } catch (err) {
+        if (!isMounted) return;
+        setError(err as FirestoreError);
         setLoading(false);
-        setError(null);
-      },
-      (err) => {
-        setError(err);
-        setLoading(false);
-      },
-    );
+      }
+    };
+
+    void start();
 
     return () => {
-      unsubscribe();
+      isMounted = false;
+      if (unsubscribe) unsubscribe();
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- switch the home page lobby to rely on the auth-safe `useArenas` hook and surface loading/error states
- wait for anonymous auth before rendering lobby content so firestore reads happen after authentication
- add loading/error handling to the admin arenas list to match the new hook contract

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf92e97f28832eaa9f81939a2a4173