### PR TITLE
Normalize passcode handling

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -15,6 +15,7 @@ import {
   findPlayerByPasscode,
   updatePlayerActivity,
   maybeConnectEmulators,
+  normalizePasscode,
 } from "../firebase";
 import type { PlayerProfile } from "../types/models";
 
@@ -55,8 +56,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setLoading(true);
       try {
         await ensureAnonAuth();
-        const trimmed = passcode.trim();
-        const playerProfile = await findPlayerByPasscode(trimmed);
+        const normalizedPasscode = normalizePasscode(passcode);
+        const playerProfile = await findPlayerByPasscode(normalizedPasscode);
         if (!playerProfile) {
           throw new Error("Invalid passcode. Ask the Boss for access.");
         }

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import {
   ensureBossProfile,
   listPlayers,
   ensureAnonAuth, // ✅ make sure we await auth before any Firestore calls
+  normalizePasscode,
 } from "../firebase";
 import type { PlayerProfile } from "../types/models";
 import { useArenas } from "../utils/useArenas";
@@ -77,9 +78,10 @@ const AdminPage = () => {
     setStatus(null);
     try {
       await ensureAnonAuth(); // ✅
+      const normalizedPasscode = normalizePasscode(playerPasscode);
       await createPlayer({
         codename: playerCodename,
-        passcode: playerPasscode,
+        passcode: normalizedPasscode,
       });
       setPlayerCodename("");
       setPlayerPasscode("");
@@ -228,3 +230,24 @@ const AdminPage = () => {
         <h2>Current Arenas</h2>
         {arenasError ? (
           <p>Failed to load arenas.</p>
+        ) : arenasLoading ? (
+          <p>Loading arenas...</p>
+        ) : arenas.length === 0 ? (
+          <p>No arenas yet.</p>
+        ) : (
+          <ul>
+            {arenas.map((arena) => (
+              <li key={arena.id}>
+                {arena.name}
+                {arena.description ? ` — ${arena.description}` : ""}
+                {arena.capacity ? ` (capacity ${arena.capacity})` : ""}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default AdminPage;


### PR DESCRIPTION
## Summary
- add a shared helper to trim and lowercase passcodes
- normalize passcode values when creating and looking up players
- update the admin form to send normalized passcodes when creating players

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf92f3b1a4832eb3d997db05294b04