### PR TITLE
feat: restyle app with monochrome shell

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,32 @@
 import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
+import AppShell from "./components/AppShell";
 import HomePage from "./pages/HomePage";
 import AdminPage from "./pages/AdminPage";
 import ArenaPage from "./pages/ArenaPage";
 import TrainingPage from "./pages/TrainingPage";
 import DebugArenaStatePage from "./pages/DebugArenaStatePage";
+import NotFoundPage from "./pages/NotFoundPage";
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<HomePage />} />
-      {/* legacy /index should work */}
-      <Route path="/index" element={<Navigate to="/" replace />} />
-      {/* alternative lobby entry point */}
-      <Route path="/lobby" element={<HomePage />} />
-
-      {/* SPA admin (separate from legacy /admin.html) */}
-      <Route path="/admin" element={<AdminPage />} />
-
-      <Route path="/arena/:arenaId" element={<ArenaPage />} />
-
-      <Route path="/debug/arena/:arenaId" element={<DebugArenaStatePage />} />
-
-      {/* the one we need */}
-      <Route path="/training" element={<TrainingPage />} />
-
-      {/* catch-all */}
-      <Route
-        path="*"
-        element={
-          <div style={{ padding: 24, color: "#e5e7eb", background: "#0f1115", minHeight: "100vh" }}>
-            Route not found. Try <a href="/">home</a>.
-          </div>
-        }
-      />
+      <Route element={<AppShell />}>
+        <Route path="/" element={<HomePage />} />
+        {/* legacy /index should work */}
+        <Route path="/index" element={<Navigate to="/" replace />} />
+        {/* alternative lobby entry point */}
+        <Route path="/lobby" element={<HomePage />} />
+        {/* SPA admin (separate from legacy /admin.html) */}
+        <Route path="/admin" element={<AdminPage />} />
+        <Route path="/arena/:arenaId" element={<ArenaPage />} />
+        <Route path="/debug/arena/:arenaId" element={<DebugArenaStatePage />} />
+        {/* the one we need */}
+        <Route path="/training" element={<TrainingPage />} />
+        {/* catch-all */}
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { NavLink, Outlet } from "react-router-dom";
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  isActive ? "active" : undefined;
+
+const AppShell = () => {
+  return (
+    <div className="app halftone">
+      <header className="header">
+        <nav className="nav">
+          <strong style={{ fontFamily: "var(--font-mono)", letterSpacing: "0.04em" }}>PASf</strong>
+          <NavLink to="/" end className={navLinkClass}>
+            Lobby
+          </NavLink>
+          <NavLink to="/admin" className={navLinkClass}>
+            Admin
+          </NavLink>
+          <NavLink to="/training" className={navLinkClass}>
+            Training
+          </NavLink>
+        </nav>
+      </header>
+      <main className="main" style={{ maxWidth: 1100, margin: "24px auto", padding: "0 16px" }}>
+        <Outlet />
+      </main>
+      <footer className="footer">
+        <span className="muted">stickfightpa · Firestore · Anonymous auth</span>
+      </footer>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
+import "./styles/base.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useState } from "react";
+import React, { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   createArena,
   createPlayer,
@@ -34,20 +34,23 @@ const AdminPage = () => {
 
   // Data
   const [players, setPlayers] = useState<PlayerProfile[]>([]);
+  const [playersLoading, setPlayersLoading] = useState(true);
   const { arenas, loading: arenasLoading, error: arenasError } = useArenas();
 
   // UI status
-  const [status, setStatus] = useState<string | null>(null);
+  const [status, setStatus] = useState<{ message: string; tone: "info" | "error" } | null>(null);
 
   useEffect(() => {
     const bootstrap = async () => {
       try {
-        await ensureAnonAuth();                // ✅ rules need auth
+        setStatus({ message: "Booting admin console…", tone: "info" });
+        await ensureAnonAuth();
         await ensureBossProfile(bossName);
         await fetchPlayers();
+        setStatus({ message: "Console ready.", tone: "info" });
       } catch (err) {
         console.error(err);
-        setStatus(`Failed to load admin data: ${extractErrorMessage(err)}`);
+        setStatus({ message: `Failed to load admin data: ${extractErrorMessage(err)}`, tone: "error" });
       }
     };
     void bootstrap();
@@ -55,27 +58,35 @@ const AdminPage = () => {
   }, []);
 
   const fetchPlayers = async () => {
-    await ensureAnonAuth();                   // ✅ guard reads too
-    const playerList = await listPlayers();
-    setPlayers(playerList);
+    try {
+      setPlayersLoading(true);
+      await ensureAnonAuth();
+      const playerList = await listPlayers();
+      setPlayers(playerList);
+    } catch (err) {
+      console.error(err);
+      setStatus({ message: `Failed to load players: ${extractErrorMessage(err)}`, tone: "error" });
+    } finally {
+      setPlayersLoading(false);
+    }
   };
 
   const handleEnsureBossProfile = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setStatus(null);
+    setStatus({ message: "Saving boss profile…", tone: "info" });
     try {
       await ensureAnonAuth();
       await ensureBossProfile(bossName);
-      setStatus("Boss profile updated.");
+      setStatus({ message: "Boss profile updated.", tone: "info" });
     } catch (err) {
       console.error(err);
-      setStatus(`Failed to update boss profile: ${extractErrorMessage(err)}`);
+      setStatus({ message: `Failed to update boss profile: ${extractErrorMessage(err)}`, tone: "error" });
     }
   };
 
   const handleCreatePlayer = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setStatus(null);
+    setStatus({ message: "Creating player…", tone: "info" });
     try {
       await ensureAnonAuth();
       await createPlayer({
@@ -84,17 +95,17 @@ const AdminPage = () => {
       });
       setPlayerCodename("");
       setPlayerPasscode("");
-      setStatus("Player created.");
+      setStatus({ message: "Player created.", tone: "info" });
       await fetchPlayers();
     } catch (err) {
       console.error(err);
-      setStatus(`Failed to create player: ${extractErrorMessage(err)}`);
+      setStatus({ message: `Failed to create player: ${extractErrorMessage(err)}`, tone: "error" });
     }
   };
 
   const handleCreateArena = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setStatus(null);
+    setStatus({ message: "Creating arena…", tone: "info" });
     try {
       await ensureAnonAuth();
       await createArena({
@@ -105,140 +116,207 @@ const AdminPage = () => {
       setArenaName("");
       setArenaDescription("");
       setArenaCapacity("");
-      setStatus("Arena created.");
+      setStatus({ message: "Arena created.", tone: "info" });
       // useArenas() will update list in real-time
     } catch (err) {
       console.error(err);
-      setStatus(`Failed to create arena: ${extractErrorMessage(err)}`);
+      setStatus({ message: `Failed to create arena: ${extractErrorMessage(err)}`, tone: "error" });
     }
   };
 
   const formsDisabled = loading;
+  const statusTone = status?.tone ?? (loading ? "info" : "info");
+  const statusMessage = useMemo(() => {
+    if (status) return status.message;
+    return loading ? "Authenticating admin…" : "All systems nominal.";
+  }, [loading, status]);
 
   return (
-    <main>
-      <section className="card">
-        <h1>Admin Console</h1>
-        <p>Use this console to manage players and arenas.</p>
-        <p>
-          <a className="button-link" href="/training-standalone.html" target="_blank" rel="noreferrer">
-            Open Training (Standalone)
-          </a>
-        </p>
-        {status ? <p>{status}</p> : null}
-      </section>
+    <div className="grid" style={{ gap: 24 }}>
+      <div
+        className={`status-bar${statusTone === "error" ? " error" : ""}`}
+        role="status"
+        aria-live="polite"
+      >
+        {statusMessage}
+      </div>
 
-      <section className="card">
-        <h2>Boss Profile</h2>
-        <form onSubmit={handleEnsureBossProfile}>
-          <fieldset disabled={formsDisabled} className="fieldset">
-            <label htmlFor="boss-name">Display name</label>
-            <input
-              id="boss-name"
-              value={bossName}
-              onChange={(e) => setBossName(e.target.value)}
-              required
-            />
-            <button className="button" type="submit">Save Boss profile</button>
-          </fieldset>
-        </form>
-      </section>
+      <div className="grid grid-2" style={{ alignItems: "start", gap: 24 }}>
+        <div className="grid" style={{ gap: 24 }}>
+          <section className="card">
+            <div className="card-header">
+              <h2>Boss Profile</h2>
+              <span className="muted">Identity</span>
+            </div>
+            <form onSubmit={handleEnsureBossProfile}>
+              <fieldset disabled={formsDisabled} className="fieldset">
+                <label htmlFor="boss-name">Display name</label>
+                <input
+                  id="boss-name"
+                  value={bossName}
+                  onChange={(e) => setBossName(e.target.value)}
+                  required
+                />
+                <button className="button" type="submit">
+                  Save Boss Profile
+                </button>
+              </fieldset>
+            </form>
+          </section>
 
-      <section className="card">
-        <h2>Add Player</h2>
-        <form onSubmit={handleCreatePlayer}>
-          <fieldset disabled={formsDisabled} className="fieldset">
-            <label htmlFor="player-codename">Codename</label>
-            <input
-              id="player-codename"
-              value={playerCodename}
-              onChange={(e) => setPlayerCodename(e.target.value)}
-              required
-            />
+          <section className="card">
+            <div className="card-header">
+              <h2>Add Player</h2>
+              <span className="muted">Credentials</span>
+            </div>
+            <form onSubmit={handleCreatePlayer}>
+              <fieldset disabled={formsDisabled} className="fieldset">
+                <label htmlFor="player-codename">Codename</label>
+                <input
+                  id="player-codename"
+                  value={playerCodename}
+                  onChange={(e) => setPlayerCodename(e.target.value)}
+                  placeholder="e.g. midnight-spark"
+                  required
+                />
 
-            <label htmlFor="player-passcode">Passcode (share privately!)</label>
-            <input
-              id="player-passcode"
-              value={playerPasscode}
-              onChange={(e) => setPlayerPasscode(e.target.value)}
-              required
-            />
+                <label htmlFor="player-passcode">Passcode (share privately)</label>
+                <input
+                  id="player-passcode"
+                  value={playerPasscode}
+                  onChange={(e) => setPlayerPasscode(e.target.value)}
+                  placeholder="auto-generated or custom"
+                  required
+                />
 
-            <button className="button" type="submit">Create Player</button>
-          </fieldset>
-        </form>
-      </section>
+                <button className="button" type="submit">
+                  Create Player
+                </button>
+              </fieldset>
+            </form>
+          </section>
 
-      <section className="card">
-        <h2>Add Arena</h2>
-        <form onSubmit={handleCreateArena}>
-          <fieldset disabled={formsDisabled} className="fieldset">
-            <label htmlFor="arena-name">Name</label>
-            <input
-              id="arena-name"
-              value={arenaName}
-              onChange={(e) => setArenaName(e.target.value)}
-              required
-            />
+          <section className="card">
+            <div className="card-header">
+              <h2>Add Arena</h2>
+              <span className="muted">Deploy</span>
+            </div>
+            <form onSubmit={handleCreateArena}>
+              <fieldset disabled={formsDisabled} className="fieldset">
+                <label htmlFor="arena-name">Name</label>
+                <input
+                  id="arena-name"
+                  value={arenaName}
+                  onChange={(e) => setArenaName(e.target.value)}
+                  placeholder="e.g. Forge Alpha"
+                  required
+                />
 
-            <label htmlFor="arena-description">Description</label>
-            <input
-              id="arena-description"
-              value={arenaDescription}
-              onChange={(e) => setArenaDescription(e.target.value)}
-            />
+                <label htmlFor="arena-description">Description</label>
+                <input
+                  id="arena-description"
+                  value={arenaDescription}
+                  onChange={(e) => setArenaDescription(e.target.value)}
+                  placeholder="Short mission brief"
+                />
 
-            <label htmlFor="arena-capacity">Capacity (optional)</label>
-            <input
-              id="arena-capacity"
-              type="number"
-              value={arenaCapacity}
-              onChange={(e) => setArenaCapacity(e.target.value)}
-              min="0"
-            />
+                <label htmlFor="arena-capacity">Capacity (optional)</label>
+                <input
+                  id="arena-capacity"
+                  type="number"
+                  value={arenaCapacity}
+                  onChange={(e) => setArenaCapacity(e.target.value)}
+                  min="0"
+                  placeholder="Max agents"
+                />
 
-            <button className="button" type="submit">Create Arena</button>
-          </fieldset>
-        </form>
-      </section>
+                <button className="button" type="submit">
+                  Create Arena
+                </button>
+              </fieldset>
+            </form>
+          </section>
+        </div>
 
-      <section className="card">
-        <h2>Current Players</h2>
-        {players.length === 0 ? (
-          <p className="empty">No players created yet.</p>
-        ) : (
-          <ul className="list">
-            {players.map((p) => (
-              <li key={p.id}>
-                {p.codename}
-                {p.passcode ? <span className="muted"> — passcode: {p.passcode}</span> : null}
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+        <div className="grid" style={{ gap: 24 }}>
+          <section className="card">
+            <div className="card-header">
+              <h2>Current Players</h2>
+              <span className="muted">Roster</span>
+            </div>
+            {playersLoading ? (
+              <ul className="list">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <li key={index}>
+                    <span className="skel" style={{ width: 160 }} />
+                    <span className="skel" style={{ width: 90 }} />
+                  </li>
+                ))}
+              </ul>
+            ) : players.length === 0 ? (
+              <p className="empty">No players created yet.</p>
+            ) : (
+              <ul className="list">
+                {players.map((p) => (
+                  <li key={p.id}>
+                    <div className="meta-grid">
+                      <strong>{p.codename}</strong>
+                      {p.lastActiveAt ? (
+                        <span className="muted">Last active {new Date(p.lastActiveAt).toLocaleString()}</span>
+                      ) : (
+                        <span className="muted">Created {new Date(p.createdAt).toLocaleString()}</span>
+                      )}
+                    </div>
+                    <div className="meta">
+                      {p.passcode ? <span className="muted">{p.passcode}</span> : <span className="muted">—</span>}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
 
-      <section className="card">
-        <h2>Current Arenas</h2>
-        {arenasError ? (
-          <p className="error">Failed to load arenas.</p>
-        ) : arenasLoading ? (
-          <p>Loading arenas...</p>
-        ) : arenas.length === 0 ? (
-          <p className="empty">No arenas created yet.</p>
-        ) : (
-          <ul className="list">
-            {arenas.map((arena) => (
-              <li key={arena.id}>
-                <strong>{arena.name}</strong>
-                {arena.description ? <span className="muted"> — {arena.description}</span> : null}
-                {arena.capacity ? <span className="muted"> (capacity {arena.capacity})</span> : null}
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+          <section className="card">
+            <div className="card-header">
+              <h2>Current Arenas</h2>
+              <span className="muted">Live grid</span>
+            </div>
+            {arenasError ? (
+              <div className="error">Failed to load arenas.</div>
+            ) : arenasLoading ? (
+              <ul className="list">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <li key={index}>
+                    <span className="skel" style={{ width: 140 }} />
+                    <span className="skel" style={{ width: 110 }} />
+                  </li>
+                ))}
+              </ul>
+            ) : arenas.length === 0 ? (
+              <p className="empty">No arenas created yet.</p>
+            ) : (
+              <ul className="list">
+                {arenas.map((arena) => (
+                  <li key={arena.id}>
+                    <div className="meta-grid">
+                      <strong>{arena.name}</strong>
+                      {arena.description ? <span className="muted">{arena.description}</span> : null}
+                    </div>
+                    <div className="meta">
+                      {arena.capacity ? (
+                        <span className="muted">Capacity {arena.capacity}</span>
+                      ) : (
+                        <span className="muted">Capacity ∞</span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { auth, db } from "../firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import {
@@ -8,6 +8,7 @@ import {
   touchPlayer,
   type ArenaState,
 } from "../lib/arenaState";
+import { useArenaPresence } from "../utils/useArenaPresence";
 
 export default function ArenaPage() {
   const { arenaId = "" } = useParams();
@@ -16,6 +17,8 @@ export default function ArenaPage() {
   const [stateReady, setStateReady] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [state, setState] = useState<ArenaState | undefined>(undefined);
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const { players: presence, loading: presenceLoading, error: presenceError } = useArenaPresence(arenaId);
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => setUid(u?.uid ?? null));
@@ -61,45 +64,93 @@ export default function ArenaPage() {
 
   const agents = useMemo(() => Object.keys(state?.players ?? {}), [state]);
 
+  const chipNames = useMemo(() => {
+    if (presence.length) {
+      return presence.map((entry) => entry.codename || entry.playerId.slice(0, 6));
+    }
+    return agents;
+  }, [agents, presence]);
+
+  const debugFooter = useMemo(() => {
+    const tick = state?.tick ?? 0;
+    const playersCount = chipNames.length;
+    return `tick=${tick} · agents=${playersCount} · ready=${stateReady}`;
+  }, [chipNames.length, state?.tick, stateReady]);
+
   return (
-    <div style={{ minHeight: "100vh", background: "#0f1115", color: "#e6e6e6" }}>
-      <div style={{ padding: 12, display: "flex", gap: 12, alignItems: "center" }}>
-        <button onClick={() => nav("/")} style={{ color: "#7dd3fc" }}>← Exit Arena</button>
-        <h2 style={{ margin: 0 }}>{arenaId || "Arena"}</h2>
-      </div>
-
-      <div style={{ padding: 12 }}>
-        <div><strong>Agents Present</strong></div>
-        <div style={{ opacity: 0.9, marginBottom: 8 }}>
-          {agents.length ? agents.join(", ") : "None"}
+    <div className="grid" style={{ gap: 24 }}>
+      <section className="card">
+        <div className="card-header">
+          <div className="meta-grid">
+            <span className="muted mono">Arena</span>
+            <h2 style={{ margin: 0 }}>{arenaId || "Arena"}</h2>
+          </div>
+          <div className="button-row">
+            <button type="button" className="button ghost" onClick={() => nav("/")}>
+              ← Lobby
+            </button>
+          </div>
         </div>
-
+        <div className="grid" style={{ gap: 16 }}>
+          <div>
+            <span className="muted mono">Tick</span>
+            <div style={{ fontSize: "var(--fs-xl)", fontFamily: "var(--font-mono)", marginTop: 4 }}>
+              {state?.tick ?? "—"}
+            </div>
+          </div>
+          <div>
+            <span className="muted mono">Agents online</span>
+            <div style={{ marginTop: 8 }}>
+              {presenceLoading ? (
+                <span className="skel" style={{ width: 140, height: 16 }} />
+              ) : chipNames.length ? (
+                <div className="chips">
+                  {chipNames.map((name) => (
+                    <span className="chip" key={name}>
+                      {name}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span className="muted">No players connected.</span>
+              )}
+            </div>
+          </div>
+        </div>
         {!stateReady && (
-          <div style={{ padding: 12, background: "#111827", borderRadius: 8 }}>
-            <div style={{ marginBottom: 6 }}>Initializing arena…</div>
-            <div style={{ fontSize: 12, opacity: 0.8 }}>
-              Waiting for live state document at <code>/arenas/{arenaId}/state</code>.
-            </div>
-            {err && (
-              <div style={{ marginTop: 8, color: "#fca5a5" }}>
-                Error: {err}
-              </div>
-            )}
+          <div className="error" style={{ marginTop: 16 }}>
+            Initializing arena… waiting for /arenas/{arenaId}/state
           </div>
         )}
+        {err ? (
+          <div className="error" style={{ marginTop: 16 }}>
+            {err}
+          </div>
+        ) : null}
+        {presenceError ? (
+          <div className="error" style={{ marginTop: 16 }}>
+            Failed to load presence data.
+          </div>
+        ) : null}
+      </section>
 
-        {stateReady && (
-          <div style={{ padding: 12, background: "#0b1220", borderRadius: 8 }}>
-            <div>Tick: {state?.tick ?? 0}</div>
-            <div style={{ fontSize: 12, opacity: 0.8 }}>
-              HP map: {JSON.stringify(state?.players ?? {})}
-            </div>
-            <div style={{ marginTop: 8, opacity: 0.8 }}>
-              Gameplay wiring next: sync inputs, apply damage, and tick at ~10Hz.
-            </div>
+      <section className="card card-canvas">
+        <div
+          ref={canvasRef}
+          className="canvas-frame"
+          style={{
+            minHeight: 420,
+            background: "radial-gradient(circle at 50% 50%, rgba(255,255,255,0.04) 0 35%, transparent 60%), var(--bg-soft)",
+            display: "grid",
+            placeItems: "center",
+          }}
+        >
+          <div className="muted" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-sm)" }}>
+            Phaser canvas bootstraps here.
           </div>
-        )}
-      </div>
+        </div>
+        <div className="card-footer">[NET] {debugFooter}</div>
+      </section>
     </div>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,12 +1,55 @@
-import React, { FormEvent, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { FormEvent, useMemo, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { useArenas } from "../utils/useArenas";
+import { useArenaPresence } from "../utils/useArenaPresence";
+import type { Arena } from "../types/models";
+
+interface ArenaListItemProps {
+  arena: Arena;
+  onJoin: (arenaId: string) => void;
+}
+
+const ArenaListItem = ({ arena, onJoin }: ArenaListItemProps) => {
+  const { players, loading: presenceLoading } = useArenaPresence(arena.id);
+  const occupancy = players.length;
+  const capacityLabel = useMemo(() => {
+    if (presenceLoading) return null;
+    if (arena.capacity) {
+      return `${occupancy}/${arena.capacity}`;
+    }
+    return `${occupancy} agents`;
+  }, [arena.capacity, occupancy, presenceLoading]);
+
+  return (
+    <li>
+      <div className="meta-grid">
+        <strong>{arena.name}</strong>
+        {arena.description ? <span className="muted">{arena.description}</span> : null}
+      </div>
+      <div className="meta">
+        {presenceLoading ? (
+          <span className="skel" style={{ width: 80, height: 14 }} />
+        ) : (
+          <span className="muted">{capacityLabel}</span>
+        )}
+        <button type="button" className="button ghost" onClick={() => onJoin(arena.id)}>
+          Join
+        </button>
+      </div>
+    </li>
+  );
+};
 
 const HomePage = () => {
   const { login, player, loading: authLoading } = useAuth();
   const navigate = useNavigate();
+  const passcodeInputRef = useRef<HTMLInputElement | null>(null);
   const [passcode, setPasscode] = useState("");
+  const [codename, setCodename] = useState<string>(() => {
+    if (typeof window === "undefined") return "";
+    return sessionStorage.getItem("pasf:lastCodename") ?? "";
+  });
   const [error, setError] = useState<string | null>(null);
   const {
     arenas,
@@ -20,91 +63,145 @@ const HomePage = () => {
     try {
       await login(passcode);
       setPasscode("");
+      if (codename) {
+        sessionStorage.setItem("pasf:lastCodename", codename);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unable to login.";
       setError(message);
     }
   };
 
-  const renderPasscodePrompt = () => (
-    <section className="card">
-      <h1>StickFight PA</h1>
-      <p>Enter the passcode provided by the Boss to access the lobby.</p>
-      <form onSubmit={handleLogin}>
-        <label htmlFor="passcode">Passcode</label>
-        <input
-          id="passcode"
-          value={passcode}
-          onChange={(event) => setPasscode(event.target.value)}
-          placeholder="e.g. thunder-fox"
-          required
-        />
-        <button type="submit" disabled={authLoading}>
-          {authLoading ? "Connecting..." : "Enter Lobby"}
-        </button>
-      </form>
-      {error ? <p role="alert">{error}</p> : null}
-    </section>
-  );
+  const handleJoinArena = (arenaId: string) => {
+    if (!player) {
+      setError("Enter your passcode before joining an arena.");
+      passcodeInputRef.current?.focus();
+      return;
+    }
+    navigate(`/arena/${arenaId}`);
+  };
+
+  const renderHeroCard = () => {
+    if (authLoading) {
+      return (
+        <section className="card">
+          <h1>Linking to Lobby…</h1>
+          <p>Establishing anonymous auth handshake. One moment.</p>
+          <div className="skel" style={{ width: "60%", height: 20 }} />
+        </section>
+      );
+    }
+
+    if (!player) {
+      return (
+        <section className="card">
+          <h1>Enter the Arena</h1>
+          <p>Secure access with the nightly passcode. Your codename is optional, but stylish.</p>
+          <form onSubmit={handleLogin} aria-live="polite">
+            <fieldset className="fieldset" disabled={authLoading}>
+              <div>
+                <label htmlFor="codename">Codename (optional)</label>
+                <input
+                  id="codename"
+                  value={codename}
+                  onChange={(event) => setCodename(event.target.value)}
+                  placeholder="e.g. shadow-fox"
+                />
+              </div>
+              <div>
+                <label htmlFor="passcode">Passcode</label>
+                <input
+                  id="passcode"
+                  ref={passcodeInputRef}
+                  value={passcode}
+                  onChange={(event) => setPasscode(event.target.value)}
+                  placeholder="Enter tonight's key"
+                  required
+                />
+              </div>
+              <button type="submit" className="button">
+                Enter Arena
+              </button>
+            </fieldset>
+            {error ? <div className="error" role="alert">{error}</div> : null}
+          </form>
+        </section>
+      );
+    }
+
+    return (
+      <section className="card">
+        <h1>Lobby Ready</h1>
+        <p>Welcome back, Agent {player.codename}. Select an arena to deploy.</p>
+        <div className="button-row">
+          <Link to="/training" className="button ghost">
+            Warmup Run
+          </Link>
+        </div>
+      </section>
+    );
+  };
 
   const renderArenaList = () => (
     <section className="card">
-      <h2>Arenas</h2>
+      <div className="card-header">
+        <h2>Live Arenas</h2>
+        <span className="muted">Realtime status</span>
+      </div>
       {arenasError ? (
-        <p role="alert">Failed to load arenas.</p>
-      ) : arenasLoading ? (
-        <p>Loading arenas…</p>
-      ) : arenas.length === 0 ? (
-        <p>No arenas created yet.</p>
-      ) : (
-        <div className="list">
-          {arenas.map((arena) => (
-            <div key={arena.id} className="list-item">
-              <div>
-                <strong>{arena.name}</strong>
-                {arena.description ? <p>{arena.description}</p> : null}
-              </div>
-              <button type="button" onClick={() => navigate(`/arena/${arena.id}`)}>
-                Join
-              </button>
-            </div>
-          ))}
+        <div className="error" role="alert">
+          Failed to load arenas.
         </div>
+      ) : arenasLoading ? (
+        <ul className="list">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <li key={index}>
+              <div className="meta-grid">
+                <span className="skel" style={{ width: 140 }} />
+                <span className="skel" style={{ width: 180 }} />
+              </div>
+              <div className="meta">
+                <span className="skel" style={{ width: 64, height: 14 }} />
+                <span className="skel" style={{ width: 80, height: 34 }} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : arenas.length === 0 ? (
+        <p className="empty">No arenas yet. Ask the Boss to create one.</p>
+      ) : (
+        <ul className="list">
+          {arenas.map((arena) => (
+            <ArenaListItem key={arena.id} arena={arena} onJoin={handleJoinArena} />
+          ))}
+        </ul>
       )}
     </section>
   );
 
   return (
-    <main>
-      {authLoading ? (
-        <section className="card">
-          <h1>Preparing lobby…</h1>
-          <p>Securing your connection. Please wait.</p>
-        </section>
-      ) : !player ? (
-        renderPasscodePrompt()
-      ) : null}
-
-      {!authLoading && player ? (
-        <section className="card">
-          <h1>Lobby</h1>
-          <p>Welcome, Agent {player.codename}. Choose an arena to jump into.</p>
-        </section>
-      ) : null}
+    <div className="grid" style={{ gap: 24 }}>
+      <div className="grid grid-2" style={{ alignItems: "start" }}>
+        {renderHeroCard()}
+        {renderArenaList()}
+      </div>
 
       <section className="card">
-        <h2>Practice</h2>
-        <p>
-          Want to warm up solo? Open the standalone training arena in a new tab and
-          practice offline.
-        </p>
-        <a className="button-link" href="/training-standalone.html" target="_blank" rel="noreferrer">
-          Open Training (Standalone)
-        </a>
+        <div className="card-header">
+          <h2>Training Grounds</h2>
+          <span className="muted">Solo drills</span>
+        </div>
+        <p>Warm up your reflexes in the single-player sandbox before the next match.</p>
+        <div className="button-row">
+          <Link to="/training" className="button">
+            Launch Training
+          </Link>
+          <a className="button ghost" href="/training-standalone.html" target="_blank" rel="noreferrer">
+            Standalone Canvas
+          </a>
+        </div>
       </section>
-
-      {!authLoading && player ? renderArenaList() : null}
-    </main>
+    </div>
   );
 };
 

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const NotFoundPage = () => {
+  return (
+    <section className="card" style={{ textAlign: "center" }}>
+      <h1>Signal Lost</h1>
+      <p>We couldn't find that route. Return to the lobby to rejoin the squad.</p>
+      <div className="button-row" style={{ justifyContent: "center" }}>
+        <Link to="/" className="button">
+          Back to Lobby
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default NotFoundPage;

--- a/src/pages/TrainingPage.tsx
+++ b/src/pages/TrainingPage.tsx
@@ -1,15 +1,15 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Phaser from "phaser";
-import { Link } from "react-router-dom";
 import { makeGame } from "../game/phaserGame";
 import TrainingScene from "../game/training/TrainingScene";
 
 const TrainingPage: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gameRef = useRef<Phaser.Game | null>(null);
+  const [launched, setLaunched] = useState(false);
 
   useEffect(() => {
-    if (!containerRef.current) {
+    if (!launched || !containerRef.current) {
       return;
     }
 
@@ -18,7 +18,7 @@ const TrainingPage: React.FC = () => {
       width: 960,
       height: 540,
       parent: containerRef.current,
-      backgroundColor: "#0f1115",
+      backgroundColor: "#0a0a0a",
       physics: { default: "arcade", arcade: { gravity: { x: 0, y: 900 }, debug: false } },
       scene: [TrainingScene],
     };
@@ -31,18 +31,41 @@ const TrainingPage: React.FC = () => {
       gameRef.current?.destroy(true);
       gameRef.current = null;
     };
-  }, []);
+  }, [launched]);
+
+  const handleLaunch = () => {
+    setLaunched(true);
+  };
 
   return (
-    <div style={{ minHeight: "100vh", background: "#0f1115", color: "#e6e6e6" }}>
-      <div style={{ padding: "12px" }}>
-        <Link to="/" style={{ color: "#7dd3fc", textDecoration: "none" }}>
-          ← Lobby
-        </Link>
-        <h2 style={{ margin: "8px 0 12px 0" }}>Training</h2>
+    <section className="card">
+      <h1>Training Module</h1>
+      <p>Run solo drills in the monochrome dojo. Launch to spin up the local Phaser scene.</p>
+      <button type="button" className="button" onClick={handleLaunch} disabled={launched}>
+        {launched ? "Training Active" : "Launch Training"}
+      </button>
+      <div
+        ref={containerRef}
+        className="canvas-frame"
+        style={{
+          marginTop: 20,
+          minHeight: launched ? 540 : 220,
+          border: "1px solid var(--line)",
+          borderRadius: "var(--radius)",
+          background: "var(--bg-soft)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {!launched ? (
+          <span className="muted" style={{ fontFamily: "var(--font-mono)", letterSpacing: "0.04em" }}>
+            Canvas warms up once launched.
+          </span>
+        ) : null}
       </div>
-      <div ref={containerRef} style={{ display: "flex", justifyContent: "center" }} />
-    </div>
+      <div className="card-footer">[SIM] arcade physics · training scene</div>
+    </section>
   );
 };
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,433 @@
+:root {
+  /* Palette */
+  --bg: #0a0a0a;
+  --bg-soft: #111;
+  --bg-elev: #161616;
+  --fg: #f5f5f5;
+  --muted: #bdbdbd;
+  --line: #2a2a2a;
+  --line-strong: #3a3a3a;
+  --ok: #f5f5f5;
+
+  /* Typography */
+  --font-sans: ui-sans-serif, Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --fs-xxl: clamp(28px, 5vw, 48px);
+  --fs-xl: 24px;
+  --fs-lg: 18px;
+  --fs-md: 16px;
+  --fs-sm: 14px;
+
+  /* Layout */
+  --radius: 16px;
+  --pad: 16px;
+  --gap: 12px;
+  --shadow: 0 0 0 1px var(--line), 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+body {
+  margin: 0;
+  font: 400 var(--fs-md) / 1.5 var(--font-sans);
+}
+
+a {
+  color: var(--fg);
+  text-underline-offset: 2px;
+  transition: opacity 0.2s ease;
+}
+
+a:focus-visible,
+a:hover {
+  opacity: 1;
+}
+
+a:focus-visible,
+button:focus-visible,
+.button-link:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  background: var(--line);
+}
+
+/* App shell */
+.app {
+  min-height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.header,
+.footer {
+  border-bottom: 1px solid var(--line);
+  padding: 12px 16px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.footer {
+  border-top: 1px solid var(--line);
+  border-bottom: 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+}
+
+.main {
+  width: 100%;
+}
+
+/* Nav */
+.nav {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.nav a {
+  opacity: 0.75;
+  text-decoration: none;
+  font-size: var(--fs-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.nav a.active,
+.nav a:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+/* Cards & panels */
+.card {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  box-shadow: var(--shadow);
+}
+
+.card h1 {
+  font-size: var(--fs-xxl);
+  margin: 0 0 12px;
+  letter-spacing: -0.02em;
+}
+
+.card h2 {
+  font-size: var(--fs-xl);
+  margin: 0 0 10px;
+  letter-spacing: -0.01em;
+}
+
+.card p {
+  margin: 0 0 12px;
+  color: var(--muted);
+}
+
+.card p:last-child {
+  margin-bottom: 0;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+}
+
+.card-footer {
+  margin-top: var(--pad);
+  padding-top: var(--gap);
+  border-top: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+}
+
+.card-canvas {
+  padding: 0;
+  overflow: hidden;
+}
+
+.card-canvas > .canvas-frame {
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.grid {
+  display: grid;
+  gap: var(--gap);
+}
+
+.grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 900px) {
+  .grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Buttons */
+.button,
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--fg);
+  color: var(--fg);
+  background: transparent;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.08s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.button:hover,
+.button-link:hover {
+  background: #fff;
+  color: #000;
+}
+
+.button:active,
+.button-link:active {
+  transform: translateY(1px);
+}
+
+.button.ghost,
+.button-link.ghost {
+  border-color: var(--line-strong);
+  color: var(--fg);
+}
+
+.button.ghost:hover,
+.button-link.ghost:hover {
+  background: var(--bg-soft);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Inputs */
+label {
+  display: block;
+  margin: 8px 0 4px;
+  color: var(--muted);
+  font-size: var(--fs-sm);
+  letter-spacing: 0.02em;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font: inherit;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--fg);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.06);
+}
+
+.fieldset {
+  display: grid;
+  gap: 10px;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.fieldset:disabled {
+  opacity: 0.6;
+}
+
+/* Lists */
+.list {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 10px 12px;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  background: var(--bg);
+}
+
+.list li:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+}
+
+.list li strong {
+  font-size: var(--fs-lg);
+  letter-spacing: -0.01em;
+}
+
+.list li .meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  text-align: right;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+/* States */
+.empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.error {
+  color: #fff;
+  background: #000;
+  border: 1px solid var(--fg);
+  padding: 8px 10px;
+  border-radius: 10px;
+  font-size: var(--fs-sm);
+}
+
+.error-inline {
+  color: #fff;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-size: var(--fs-sm);
+}
+
+.skel {
+  background: #1a1a1a;
+  height: 1rem;
+  border-radius: 6px;
+  animation: pulse 1.4s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Artistic background */
+.halftone {
+  background:
+    radial-gradient(circle at 10% 10%, rgba(255, 255, 255, 0.04) 0 2px, transparent 2px) 0 0 / 16px 16px,
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.02) 0 1px, transparent 1px) 8px 8px / 16px 16px,
+    var(--bg);
+}
+
+.status-bar {
+  border: 1px solid var(--line);
+  background: var(--bg-soft);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--fg);
+}
+
+.status-bar.error {
+  border-color: var(--fg);
+  background: #000;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: var(--fs-sm);
+  font-family: var(--font-mono);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+pre {
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  overflow: auto;
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.meta-grid {
+  display: grid;
+  gap: 4px;
+}
+
+.small-print {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+}

--- a/src/utils/useArenaPresence.ts
+++ b/src/utils/useArenaPresence.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import type { FirestoreError, Unsubscribe } from "firebase/firestore";
+import { ensureAnonAuth, watchArenaPresence } from "../firebase";
+import type { ArenaPresenceEntry } from "../types/models";
+
+interface UseArenaPresenceResult {
+  players: ArenaPresenceEntry[];
+  loading: boolean;
+  error: FirestoreError | null;
+}
+
+export function useArenaPresence(arenaId?: string): UseArenaPresenceResult {
+  const [players, setPlayers] = useState<ArenaPresenceEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<FirestoreError | null>(null);
+
+  useEffect(() => {
+    if (!arenaId) {
+      setPlayers([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let unsub: Unsubscribe | undefined;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        await ensureAnonAuth();
+        if (cancelled) return;
+        unsub = watchArenaPresence(arenaId, (entries) => {
+          if (cancelled) return;
+          setPlayers(entries);
+          setLoading(false);
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setError(err as FirestoreError);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unsub?.();
+    };
+  }, [arenaId]);
+
+  return { players, loading, error };
+}


### PR DESCRIPTION
## Summary
- add a shared monochrome design system and app shell navigation
- rebuild lobby, admin, arena, training, debug, and 404 views around cards, grids, and skeleton states
- surface live arena presence counts with a reusable hook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf95296410832eb341f863e146fc9d