### PR TITLE
Refine player creation to decouple passcodes

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -132,7 +132,6 @@ export interface BossProfile {
 export interface PlayerProfile {
   id: string;
   codename: string;
-  passcode?: string;
   createdAt: ISODate;
   lastActiveAt?: ISODate;
 }
@@ -199,19 +198,20 @@ export const normalizePasscode = (passcode: string) => passcode.trim().toLowerCa
 
 export const createPlayer = async (input: CreatePlayerInput) => {
   await ensureAnonAuth();
-  const playersRef = collection(db, "players");
   const now = serverTimestamp();
   const normalizedPasscode = normalizePasscode(input.passcode);
-  const pRef = await addDoc(playersRef, {
+  const playersRef = collection(db, "players");
+  const playerRef = doc(playersRef);
+  await setDoc(playerRef, {
     codename: input.codename,
-    passcode: normalizedPasscode,
     createdAt: now,
+    lastActiveAt: now,
   });
   await setDoc(doc(db, "passcodes", normalizedPasscode), {
-    playerId: pRef.id,
+    playerId: playerRef.id,
     createdAt: now,
   });
-  return pRef.id;
+  return playerRef.id;
 };
 
 export const findPlayerByPasscode = async (passcode: string) => {
@@ -225,7 +225,6 @@ export const findPlayerByPasscode = async (passcode: string) => {
       return {
         id: pSnap.id,
         codename: d.codename,
-        passcode: d.passcode,
         createdAt: d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
         lastActiveAt: d.lastActiveAt?.toDate?.().toISOString?.(),
       } as PlayerProfile;
@@ -242,7 +241,6 @@ export const findPlayerByPasscode = async (passcode: string) => {
     return {
       id: s.id,
       codename: d.codename,
-      passcode: d.passcode,
       createdAt: d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
       lastActiveAt: d.lastActiveAt?.toDate?.().toISOString?.(),
     } as PlayerProfile;
@@ -269,7 +267,6 @@ export const listPlayers = async (): Promise<PlayerProfile[]> => {
     return {
       id: s.id,
       codename: d.codename,
-      passcode: d.passcode,
       createdAt: d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
       lastActiveAt: d.lastActiveAt?.toDate?.().toISOString?.(),
     } as PlayerProfile;

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -267,9 +267,6 @@ const AdminPage = () => {
                         <span className="muted">Created {new Date(p.createdAt).toLocaleString()}</span>
                       )}
                     </div>
-                    <div className="meta">
-                      {p.passcode ? <span className="muted">{p.passcode}</span> : <span className="muted">—</span>}
-                    </div>
                   </li>
                 ))}
               </ul>

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -7,7 +7,6 @@ export interface BossProfile {
 export interface PlayerProfile {
   id: string;
   codename: string;
-  passcode?: string;
   createdAt: string;
   lastActiveAt?: string;
 }


### PR DESCRIPTION
## Summary
- write player documents using explicit doc refs so they only store codename and timestamps
- keep passcode credentials exclusively in the `/passcodes` mapping and update serializers to omit passcode data
- drop the admin roster UI dependency on `player.passcode`

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfa4f420f4832eb20e330d83df32e4