### PR TITLE
Ensure anon auth before listing players

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -263,15 +263,20 @@ export const loginWithPasscode = async (passcode: string): Promise<PlayerProfile
 };
 
 export const listPlayers = async (): Promise<PlayerProfile[]> => {
+  await ensureAnonAuth();
   const snapshot = await getDocs(collection(db, "players"));
-  return snapshot.docs.map((s) => {
-    const d = s.data() as any;
+  return snapshot.docs.map((docSnap) => {
+    const data = docSnap.data() as any;
+    const { passcode: _ignoredPasscode, ...rest } = data ?? {};
+    const createdAt =
+      data?.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString();
+    const lastActiveAt = data?.lastActiveAt?.toDate?.().toISOString?.();
+
     return {
-      id: s.id,
-      codename: d.codename,
-      passcode: d.passcode,
-      createdAt: d.createdAt?.toDate?.().toISOString?.() ?? new Date().toISOString(),
-      lastActiveAt: d.lastActiveAt?.toDate?.().toISOString?.(),
+      id: docSnap.id,
+      ...rest,
+      createdAt,
+      lastActiveAt,
     } as PlayerProfile;
   });
 };


### PR DESCRIPTION
## Summary
- ensure anonymous authentication is established before fetching the players collection
- normalize `listPlayers` return shape to `{ id, ...data }` while dropping legacy passcode data

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfa4fab3ec832e96783865e91ee82a