### PR TITLE
Ensure arena watcher waits for auth before subscribing

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -429,8 +429,32 @@ export async function updateArenaPlayerState(
 }
 
 export function watchArenaState(arenaId: string, cb: (state: any) => void) {
-  const ref = arenaStateDoc(arenaId);
-  return onSnapshot(ref, (snap) => cb(snap.exists() ? snap.data() : undefined));
+  let unsubscribe: Unsubscribe | null = null;
+  let cancelled = false;
+
+  ensureAnonAuth()
+    .then(() => {
+      if (cancelled) return;
+      const ref = arenaStateDoc(arenaId);
+      unsubscribe = onSnapshot(ref, (snap) =>
+        cb(snap.exists() ? snap.data() : undefined),
+      );
+      if (cancelled && unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
+    })
+    .catch((error) => {
+      console.error("[firebase] watchArenaState failed to auth", error);
+    });
+
+  return () => {
+    cancelled = true;
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  };
 }
 
 export async function applyDamage(arenaId: string, targetPlayerId: string, amount: number) {


### PR DESCRIPTION
## Summary
- delay arena state subscriptions until anonymous auth completes
- retain the unsubscribe handle once the snapshot listener is registered
- make the returned cleanup safe to call before the listener is ready

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfab042b58832ea723ceb78830dc37