### PR TITLE
Adjust arena state rules path and update deployment notes

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -35,3 +35,6 @@ findPlayerByPasscode("shadowblade") => { id: "dG7ci5dDLJYbPE1l1x2U", codename: "
 - The arena subscription immediately receives the initial roster, and subsequent Firestore updates push live roster changes to the client.
 
 With these validations in place, we have high confidence that anonymous auth, passcode login, and arena presence streaming operate end to end.
+
+## Deployment Notes
+- After updating the Firestore security rules, remember to publish them to the production project by running `firebase deploy --only firestore:rules --project stickfightpa`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -17,8 +17,8 @@ service cloud.firestore {
       }
     }
 
-    // IMPORTANT: single state doc at /arenas/{arenaId}/state
-    match /arenas/{arenaId}/state {
+    // IMPORTANT: arena state docs live at /arenas/{arenaId}/state/{stateId}
+    match /arenas/{arenaId}/state/{stateId} {
       allow read, write: if isSignedIn();
     }
 


### PR DESCRIPTION
## Summary
- update the arena state security rule to match documents stored at `/arenas/{arenaId}/state/{stateId}`
- document the requirement to deploy the revised Firestore rules to the `stickfightpa` project

## Testing
- `npx firebase deploy --only firestore:rules --dry-run` *(fails: npm 403 fetching firebase-tools in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfab2079c0832e8662c2a09c12038a