### PR TITLE
Refactor arena networking around authoritative host loop

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -22,6 +22,7 @@ import {
   orderBy,
   onSnapshot,
   runTransaction,
+  type QueryDocumentSnapshot,
   type Unsubscribe,
 } from "firebase/firestore";
 
@@ -160,6 +161,33 @@ export type ArenaPlayerState = {
   anim?: string;
   hp: number;
 };
+
+export interface ArenaInputSnapshot {
+  playerId: string;
+  codename?: string;
+  left?: boolean;
+  right?: boolean;
+  jump?: boolean;
+  attack?: boolean;
+  updatedAt?: ISODate;
+}
+
+export interface ArenaStateWritePlayer {
+  codename?: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  facing: "L" | "R";
+  hp: number;
+  anim?: string;
+}
+
+export interface ArenaStateWrite {
+  tick: number;
+  tMs: number;
+  players: Record<string, ArenaStateWritePlayer>;
+}
 
 export interface LeaderboardEntry {
   id: string;
@@ -393,6 +421,33 @@ export const watchArenaPresence = (
 const arenaStateDoc = (arenaId: string) =>
   doc(db, "arenas", arenaId, "state", "current");
 
+const arenaInputDoc = (arenaId: string, playerId: string) =>
+  doc(db, "arenas", arenaId, "inputs", playerId);
+
+const arenaInputsCollection = (arenaId: string) =>
+  collection(db, "arenas", arenaId, "inputs");
+
+const readTimestamp = (value: unknown): ISODate | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const date = (value as { toDate?: () => Date }).toDate?.();
+  return date?.toISOString();
+};
+
+const serializeInputSnapshot = (snap: QueryDocumentSnapshot): ArenaInputSnapshot => {
+  const data = snap.data() as Record<string, unknown>;
+  return {
+    playerId: (data.playerId as string) ?? snap.id,
+    codename: (data.codename as string) ?? undefined,
+    left: typeof data.left === "boolean" ? data.left : undefined,
+    right: typeof data.right === "boolean" ? data.right : undefined,
+    jump: typeof data.jump === "boolean" ? data.jump : undefined,
+    attack: typeof data.attack === "boolean" ? data.attack : undefined,
+    updatedAt: readTimestamp(data.updatedAt),
+  };
+};
+
 export async function initArenaPlayerState(
   arenaId: string,
   me: { id: string; codename: string },
@@ -471,6 +526,71 @@ export function watchArenaState(arenaId: string, cb: (state: any) => void) {
       unsubscribe = null;
     }
   };
+}
+
+export interface ArenaInputWrite {
+  left?: boolean;
+  right?: boolean;
+  jump?: boolean;
+  attack?: boolean;
+  codename?: string;
+}
+
+export async function writeArenaInput(
+  arenaId: string,
+  playerId: string,
+  input: ArenaInputWrite,
+): Promise<void> {
+  await ensureAnonAuth();
+  const ref = arenaInputDoc(arenaId, playerId);
+  const payload: Record<string, unknown> = {
+    playerId,
+    updatedAt: serverTimestamp(),
+  };
+  if (typeof input.left === "boolean") payload.left = input.left;
+  if (typeof input.right === "boolean") payload.right = input.right;
+  if (typeof input.jump === "boolean") payload.jump = input.jump;
+  if (typeof input.attack === "boolean") payload.attack = input.attack;
+  if (input.codename) payload.codename = input.codename;
+  await setDoc(ref, payload, { merge: true });
+}
+
+export async function fetchArenaInputs(arenaId: string): Promise<ArenaInputSnapshot[]> {
+  await ensureAnonAuth();
+  const snapshot = await getDocs(arenaInputsCollection(arenaId));
+  return snapshot.docs.map(serializeInputSnapshot);
+}
+
+export function watchArenaInputs(
+  arenaId: string,
+  cb: (inputs: ArenaInputSnapshot[]) => void,
+): Unsubscribe {
+  const q = query(arenaInputsCollection(arenaId));
+  return onSnapshot(q, (snapshot) => {
+    cb(snapshot.docs.map(serializeInputSnapshot));
+  });
+}
+
+export async function writeArenaState(arenaId: string, state: ArenaStateWrite): Promise<void> {
+  await ensureAnonAuth();
+  const ref = arenaStateDoc(arenaId);
+  const players: Record<string, Record<string, unknown>> = {};
+  for (const [playerId, data] of Object.entries(state.players)) {
+    players[playerId] = {
+      ...data,
+      updatedAt: serverTimestamp(),
+    };
+  }
+  await setDoc(
+    ref,
+    {
+      tick: state.tick,
+      tMs: state.tMs,
+      players,
+      lastUpdate: serverTimestamp(),
+    },
+    { merge: true },
+  );
 }
 
 export async function applyDamage(arenaId: string, targetPlayerId: string, amount: number) {

--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -127,6 +127,18 @@ export class Player extends Phaser.Events.EventEmitter {
     }
   }
 
+  getInputFlags() {
+    if (!this.controlsEnabled) {
+      return { left: false, right: false, jump: false, attack: false };
+    }
+    return {
+      left: this.controls.left.isDown,
+      right: this.controls.right.isDown,
+      jump: this.controls.jump.some((key) => key.isDown),
+      attack: this.controls.attack.isDown,
+    };
+  }
+
   isAttackActive() {
     return this.attackTimer > 0;
   }

--- a/src/game/net/hostLoop.ts
+++ b/src/game/net/hostLoop.ts
@@ -1,0 +1,186 @@
+import {
+  fetchArenaInputs,
+  writeArenaState,
+  type ArenaInputSnapshot,
+  type ArenaStateWrite,
+} from "../../firebase";
+import { applyActions, getSnapshot, initSim } from "../../sim/reducer";
+import type { ActionDoc, Sim } from "../../sim/types";
+
+export interface HostLoopOptions {
+  arenaId: string;
+  hostId: string;
+  tickRateHz?: number;
+  seed?: number;
+  log?: typeof console;
+}
+
+export interface HostLoopController {
+  stop(): void;
+}
+
+const DEFAULT_TICK_RATE = 11;
+const MAX_DT_MS = 250;
+
+function buildActions(
+  arenaId: string,
+  participants: ArenaInputSnapshot[],
+  seqByPlayer: Map<string, number>,
+  timestamp: number,
+): ActionDoc[] {
+  return participants.map((participant) => {
+    const nextSeq = (seqByPlayer.get(participant.playerId) ?? 0) + 1;
+    seqByPlayer.set(participant.playerId, nextSeq);
+    return {
+      arenaId,
+      playerId: participant.playerId,
+      seq: nextSeq,
+      input: {
+        left: !!participant.left,
+        right: !!participant.right,
+        jump: !!participant.jump,
+        attack: !!participant.attack,
+      },
+      clientTs: timestamp,
+    };
+  });
+}
+
+function makeStateWrite(
+  participants: ArenaInputSnapshot[],
+  snapshot: ReturnType<typeof getSnapshot>,
+): ArenaStateWrite {
+  const inputsById = new Map(participants.map((p) => [p.playerId, p]));
+  const players: ArenaStateWrite["players"] = {};
+  for (const [playerId, state] of Object.entries(snapshot.players)) {
+    const input = inputsById.get(playerId);
+    players[playerId] = {
+      codename: input?.codename,
+      x: state.pos.x,
+      y: state.pos.y,
+      vx: state.vel.x,
+      vy: state.vel.y,
+      facing: state.dir === -1 ? "L" : "R",
+      hp: state.hp,
+      anim: state.attackActiveUntil > snapshot.tMs ? "attack" : undefined,
+    };
+  }
+  return {
+    tick: snapshot.tick,
+    tMs: snapshot.tMs,
+    players,
+  };
+}
+
+function selectParticipants(
+  inputs: ArenaInputSnapshot[],
+  hostId: string,
+): ArenaInputSnapshot[] {
+  if (!inputs.length) {
+    return [];
+  }
+  const byId = new Map(inputs.map((entry) => [entry.playerId, entry]));
+  const sortedIds = [...byId.keys()].sort();
+  if (byId.has(hostId)) {
+    const index = sortedIds.indexOf(hostId);
+    if (index > 0) {
+      sortedIds.splice(index, 1);
+      sortedIds.unshift(hostId);
+    }
+  }
+  const selected = sortedIds.slice(0, 2).map((id) => byId.get(id)).filter(Boolean) as ArenaInputSnapshot[];
+  return selected.length === 2 ? selected : [];
+}
+
+export function startHostLoop(options: HostLoopOptions): HostLoopController {
+  const tickRate = options.tickRateHz ?? DEFAULT_TICK_RATE;
+  const intervalMs = Math.max(1, Math.round(1000 / tickRate));
+  const logger = options.log ?? console;
+
+  let stopped = false;
+  let busy = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let sim: Sim | null = null;
+  let playerOrder: string[] = [];
+  let lastStepAt = Date.now();
+  const seqByPlayer = new Map<string, number>();
+
+  const resetSim = (participants: ArenaInputSnapshot[]) => {
+    if (participants.length < 2) {
+      sim = null;
+      playerOrder = [];
+      seqByPlayer.clear();
+      return;
+    }
+    const [a, b] = participants;
+    sim = initSim({
+      seed: options.seed ?? 1,
+      myPlayerId: a.playerId,
+      opponentId: b.playerId,
+    });
+    playerOrder = [a.playerId, b.playerId];
+    seqByPlayer.clear();
+    lastStepAt = Date.now();
+    logger.info?.("[hostLoop] sim reset", { arenaId: options.arenaId, players: playerOrder });
+  };
+
+  const step = async () => {
+    if (stopped || busy) {
+      return;
+    }
+    busy = true;
+    try {
+      const inputs = await fetchArenaInputs(options.arenaId);
+      const participants = selectParticipants(inputs, options.hostId);
+      if (!participants.length) {
+        sim = null;
+        playerOrder = [];
+        seqByPlayer.clear();
+        return;
+      }
+
+      const currentOrder = participants.map((p) => p.playerId);
+      if (currentOrder.join("|") !== playerOrder.join("|")) {
+        resetSim(participants);
+      }
+
+      if (!sim) {
+        return;
+      }
+
+      const now = Date.now();
+      const dtMs = Math.min(Math.max(now - lastStepAt, 0), MAX_DT_MS);
+      lastStepAt = now;
+
+      const actions = buildActions(options.arenaId, participants, seqByPlayer, now);
+      applyActions(sim, actions, dtMs);
+      const snapshot = getSnapshot(sim);
+      const stateWrite = makeStateWrite(participants, snapshot);
+      await writeArenaState(options.arenaId, stateWrite);
+    } catch (error) {
+      logger.error?.("[hostLoop] step error", error);
+    } finally {
+      busy = false;
+    }
+  };
+
+  timer = setInterval(() => {
+    void step();
+  }, intervalMs);
+
+  logger.info?.("[hostLoop] started", { arenaId: options.arenaId, tickRate });
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      sim = null;
+      playerOrder = [];
+      seqByPlayer.clear();
+      logger.info?.("[hostLoop] stopped", { arenaId: options.arenaId });
+    },
+  };
+}

--- a/src/net/ActionBus.ts
+++ b/src/net/ActionBus.ts
@@ -1,60 +1,34 @@
-import {
-  addDoc,
-  collection,
-  doc,
-  getDoc,
-  onSnapshot,
-  orderBy,
-  query,
-  serverTimestamp,
-  setDoc,
-  type DocumentData,
-  type Unsubscribe,
-} from "firebase/firestore";
-import { db } from "../firebase";
+import { writeArenaInput, type ArenaInputWrite } from "../firebase";
 
 const THROTTLE_MS = 100;
-const LAST_SEQ_WRITE_INTERVAL = 1500;
 
 export interface PlayerInput {
   left?: boolean;
   right?: boolean;
   jump?: boolean;
   attack?: boolean;
+  codename?: string;
 }
 
-export interface NormalizedInput {
+interface NormalizedInput {
   left: boolean;
   right: boolean;
   jump: boolean;
   attack: boolean;
 }
 
-export interface ActionDocument {
-  id?: string;
-  arenaId: string;
-  playerId: string;
-  seq: number;
-  input: NormalizedInput;
-  clientTs: number;
-  createdAt?: DocumentData;
-}
-
 interface InitOptions {
   arenaId: string;
   playerId: string;
-  onRemoteActions: (actions: ActionDocument[]) => void;
+  codename?: string;
 }
 
 interface ActionBusState {
   arenaId: string;
   playerId: string;
-  seq: number;
-  onRemoteActions: (actions: ActionDocument[]) => void;
-  unsubscribe?: Unsubscribe;
+  codename?: string;
   ready: boolean;
   lastSendAt: number;
-  lastSeqWriteAt: number;
   lastSentPayload?: NormalizedInput;
   latestInput: NormalizedInput;
   pendingPayload?: NormalizedInput;
@@ -88,85 +62,42 @@ function inputsEqual(a?: NormalizedInput, b?: NormalizedInput): boolean {
   return a.left === b.left && a.right === b.right && a.jump === b.jump && a.attack === b.attack;
 }
 
-async function ensurePlayerStateDoc(arenaId: string, playerId: string) {
-  const ref = doc(db, "arenas", arenaId, "players", playerId);
-  const snap = await getDoc(ref);
-  if (!snap.exists()) {
-    await setDoc(
-      ref,
-      {
-        playerId,
-        name: playerId,
-        joinedAt: serverTimestamp(),
-        isReady: false,
-        hp: 100,
-        pos: { x: 0, y: 0 },
-        dir: 1,
-        lastSeq: 0,
-      },
-      { merge: true },
-    );
-    return 0;
-  }
-  const data = snap.data() as { lastSeq?: number };
-  return typeof data.lastSeq === "number" ? data.lastSeq : 0;
+function toWritePayload(input: NormalizedInput, codename?: string): ArenaInputWrite {
+  return {
+    left: input.left,
+    right: input.right,
+    jump: input.jump,
+    attack: input.attack,
+    codename,
+  };
 }
 
-async function sendAction(state: ActionBusState, payload: NormalizedInput) {
-  const seq = state.seq + 1;
-  state.seq = seq;
+async function sendInput(state: ActionBusState, payload: NormalizedInput) {
   state.lastSentPayload = cloneNormalized(payload);
   state.lastSendAt = Date.now();
   state.pendingPayload = undefined;
-
-  const data = {
-    arenaId: state.arenaId,
-    playerId: state.playerId,
-    seq,
-    input: payload,
-    clientTs: Date.now(),
-    createdAt: serverTimestamp(),
-  };
-
   try {
-    await addDoc(collection(db, "arenas", state.arenaId, "actions"), data);
-    console.info(`[NET] sent seq=${seq}`, data);
-  } catch (err) {
-    console.error("[NET] send error", err);
-  }
-
-  const now = Date.now();
-  if (now - state.lastSeqWriteAt > LAST_SEQ_WRITE_INTERVAL || seq % 10 === 0) {
-    state.lastSeqWriteAt = now;
-    try {
-      await setDoc(
-        doc(db, "arenas", state.arenaId, "players", state.playerId),
-        { lastSeq: seq },
-        { merge: true },
-      );
-    } catch (err) {
-      console.warn("[NET] lastSeq update skipped", err);
-    }
+    await writeArenaInput(state.arenaId, state.playerId, toWritePayload(payload, state.codename));
+  } catch (error) {
+    console.warn("[NET] input publish failed", error);
   }
 }
 
 function scheduleSend(state: ActionBusState, payload: NormalizedInput) {
   if (inputsEqual(state.lastSentPayload, payload)) {
-    console.debug("[NET] dedupe", payload);
     return;
   }
 
   const now = Date.now();
   const elapsed = now - state.lastSendAt;
   if (elapsed >= THROTTLE_MS && !state.pendingTimer) {
-    void sendAction(state, payload);
+    void sendInput(state, payload);
     return;
   }
 
   state.pendingPayload = cloneNormalized(payload);
   if (!state.pendingTimer) {
     const delay = Math.max(THROTTLE_MS - elapsed, 0);
-    console.debug("[NET] throttle", { delay, payload });
     state.pendingTimer = setTimeout(() => {
       state.pendingTimer = undefined;
       const toSend = state.pendingPayload;
@@ -175,10 +106,9 @@ function scheduleSend(state: ActionBusState, payload: NormalizedInput) {
         return;
       }
       if (inputsEqual(state.lastSentPayload, toSend)) {
-        console.debug("[NET] dedupe", toSend);
         return;
       }
-      void sendAction(state, toSend);
+      void sendInput(state, toSend);
     }, delay);
   }
 }
@@ -188,55 +118,30 @@ export async function initActionBus(options: InitOptions): Promise<void> {
     disposeActionBus();
   }
 
-  const seq = await ensurePlayerStateDoc(options.arenaId, options.playerId);
-
   const state: ActionBusState = {
     arenaId: options.arenaId,
     playerId: options.playerId,
-    seq,
-    onRemoteActions: options.onRemoteActions,
-    ready: false,
+    codename: options.codename,
+    ready: true,
     lastSendAt: 0,
-    lastSeqWriteAt: Date.now(),
     latestInput: cloneNormalized(defaultInput),
   };
 
-  const actionsRef = collection(db, "arenas", options.arenaId, "actions");
-  const q = query(actionsRef, orderBy("createdAt", "asc"));
-
-  state.unsubscribe = onSnapshot(
-    q,
-    (snapshot) => {
-      const batch: ActionDocument[] = [];
-      snapshot.docChanges().forEach((change) => {
-        if (change.type !== "added") return;
-        const data = change.doc.data() as ActionDocument;
-        if (!data) return;
-        if (data.playerId === options.playerId) return;
-        const action: ActionDocument = {
-          id: change.doc.id,
-          ...data,
-        };
-        batch.push(action);
-      });
-      if (batch.length > 0) {
-        console.info(`[NET] recv batch size=${batch.length}`, batch);
-        state.onRemoteActions(batch);
-      }
-    },
-    (error) => {
-      console.error("[NET] subscribe error", error);
-    },
-  );
-
-  state.ready = true;
   busState = state;
-  console.info("[NET] subscribe actions ok");
+  try {
+    await writeArenaInput(options.arenaId, options.playerId, toWritePayload(defaultInput, options.codename));
+  } catch (error) {
+    console.warn("[NET] initial input publish skipped", error);
+  }
 }
 
 export function publishInput(input: PlayerInput): void {
   if (!busState || !busState.ready) {
     return;
+  }
+
+  if (input.codename) {
+    busState.codename = input.codename;
   }
 
   const next = normalizeInput(input, busState.latestInput);
@@ -250,10 +155,8 @@ export function publishInput(input: PlayerInput): void {
 
 export function disposeActionBus(): void {
   if (!busState) return;
-  busState.unsubscribe?.();
   if (busState.pendingTimer) {
     clearTimeout(busState.pendingTimer);
   }
-  console.info("[NET] bus disposed");
   busState = null;
 }


### PR DESCRIPTION
## Summary
- add Firestore helpers for arena input snapshots and state writes
- replace the /actions queue with an input bus that throttles writes to /arenas/{id}/inputs/{uid}
- introduce a host loop that advances the deterministic sim and mirrors snapshots to /state/current
- update the Phaser arena client to publish inputs, consume authoritative snapshots, and smooth opponent motion

## Testing
- pnpm run typecheck
- pnpm run test:build

------
https://chatgpt.com/codex/tasks/task_e_68cfb760c130832ead0e4167c6cf6de3