### PR TITLE
Add arena seat claims and host-controlled bootstrap

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -150,6 +150,13 @@ export interface ArenaPresenceEntry {
   joinedAt?: ISODate;
 }
 
+export interface ArenaSeatAssignment {
+  seatNo: number;
+  playerId: string;
+  uid: string;
+  joinedAt?: ISODate;
+}
+
 export type ArenaPlayerState = {
   codename: string;
   x: number;
@@ -365,6 +372,108 @@ export const joinArena = async (
 
 export const leaveArena = async (arenaId: string, presenceId: string) => {
   await deleteDoc(doc(db, `arenas/${arenaId}/presence/${presenceId}`));
+};
+
+const seatDoc = (arenaId: string, seatNo: number) =>
+  doc(db, `arenas/${arenaId}/seats/${seatNo}`);
+
+const normalizeSeatPlayerId = (playerId: string | null | undefined, uid: string) =>
+  playerId && playerId.trim().length > 0 ? playerId : uid;
+
+export const claimArenaSeat = async (
+  arenaId: string,
+  seatNo: number,
+  identity: { playerId?: string | null; uid: string },
+) => {
+  await ensureAnonAuth();
+  const seatId = `${seatNo}`;
+  const playerId = normalizeSeatPlayerId(identity.playerId, identity.uid);
+  const seatRef = seatDoc(arenaId, seatNo);
+  const seatsCollection = collection(db, `arenas/${arenaId}/seats`);
+  const seatSnapshot = await getDocs(seatsCollection);
+  const seatRefs = seatSnapshot.docs.map((snap) => snap.ref);
+
+  await runTransaction(db, async (tx) => {
+    const currentSnap = await tx.get(seatRef);
+    if (currentSnap.exists()) {
+      const data = currentSnap.data() as any;
+      const alreadyMine =
+        data?.uid === identity.uid || (playerId && data?.playerId === playerId);
+      if (!alreadyMine) {
+        throw new Error("Seat is already occupied.");
+      }
+    }
+
+    for (const ref of seatRefs) {
+      if (ref.id === seatId) continue;
+      const otherSnap = await tx.get(ref);
+      if (!otherSnap.exists()) continue;
+      const data = otherSnap.data() as any;
+      const matchesUid = data?.uid === identity.uid;
+      const matchesPlayer = playerId && data?.playerId === playerId;
+      if (matchesUid || matchesPlayer) {
+        tx.delete(ref);
+      }
+    }
+
+    tx.set(
+      seatRef,
+      {
+        playerId,
+        uid: identity.uid,
+        joinedAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+  });
+};
+
+export const releaseArenaSeat = async (
+  arenaId: string,
+  seatNo: number,
+  identity?: { playerId?: string | null; uid: string },
+) => {
+  await ensureAnonAuth();
+  const seatRef = seatDoc(arenaId, seatNo);
+  const playerId = identity ? normalizeSeatPlayerId(identity.playerId, identity.uid) : null;
+
+  await runTransaction(db, async (tx) => {
+    const snap = await tx.get(seatRef);
+    if (!snap.exists()) return;
+    const data = snap.data() as any;
+    if (identity) {
+      const matchesUid = data?.uid === identity.uid;
+      const matchesPlayer = playerId && data?.playerId === playerId;
+      if (!matchesUid && !matchesPlayer) {
+        return;
+      }
+    }
+    tx.delete(seatRef);
+  });
+};
+
+export const watchArenaSeats = (
+  arenaId: string,
+  cb: (seats: ArenaSeatAssignment[]) => void,
+): Unsubscribe => {
+  const seatsRef = collection(db, `arenas/${arenaId}/seats`);
+  return onSnapshot(seatsRef, (snapshot) => {
+    const seats = snapshot.docs
+      .map((docSnap) => {
+        const data = docSnap.data() as any;
+        const seatNo = Number.parseInt(docSnap.id, 10);
+        if (Number.isNaN(seatNo)) return null;
+        return {
+          seatNo,
+          playerId: data?.playerId ?? "",
+          uid: data?.uid ?? "",
+          joinedAt: data?.joinedAt?.toDate?.().toISOString?.(),
+        } as ArenaSeatAssignment;
+      })
+      .filter((seat): seat is ArenaSeatAssignment => !!seat)
+      .sort((a, b) => a.seatNo - b.seatNo);
+    cb(seats);
+  });
 };
 
 export const watchArenaPresence = (

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { db, ensureAnonAuth, joinArena, leaveArena } from "../firebase";
+import Phaser from "phaser";
+import {
+  db,
+  ensureAnonAuth,
+  joinArena,
+  leaveArena,
+  claimArenaSeat,
+  releaseArenaSeat,
+  initArenaPlayerState,
+} from "../firebase";
 import {
   ensureArenaState,
   watchArenaState,
@@ -8,7 +17,10 @@ import {
   type ArenaState,
 } from "../lib/arenaState";
 import { useArenaPresence } from "../utils/useArenaPresence";
+import { useArenaSeats } from "../utils/useArenaSeats";
 import { useAuth } from "../context/AuthContext";
+import { makeGame } from "../game/phaserGame";
+import ArenaScene from "../game/arena/ArenaScene";
 
 export default function ArenaPage() {
   const { arenaId = "" } = useParams();
@@ -17,8 +29,14 @@ export default function ArenaPage() {
   const [err, setErr] = useState<string | null>(null);
   const [state, setState] = useState<ArenaState | undefined>(undefined);
   const canvasRef = useRef<HTMLDivElement | null>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
   const { players: presence, loading: presenceLoading, error: presenceError } = useArenaPresence(arenaId);
-  const { user, player, loading: authLoading, authReady } = useAuth();
+  const { seats, loading: seatsLoading, error: seatsError } = useArenaSeats(arenaId);
+  const { user, player, authReady } = useAuth();
+  const [seatBusy, setSeatBusy] = useState<number | null>(null);
+  const [seatMessage, setSeatMessage] = useState<string | null>(null);
+
+  type SeatEntry = (typeof seats)[number];
 
   // Auto-init + subscribe
   useEffect(() => {
@@ -153,11 +171,147 @@ export default function ArenaPage() {
     return agents;
   }, [agents, presence]);
 
+  const seatMap = useMemo(() => {
+    const map = new Map<number, SeatEntry>();
+    seats.forEach((seat) => {
+      map.set(seat.seatNo, seat);
+    });
+    return map;
+  }, [seats]);
+
+  const meUid = user?.uid ?? null;
+  const meProfileId = player?.id ?? null;
+
+  const isSeatMine = (seat?: SeatEntry) => {
+    if (!seat || !meUid) return false;
+    if (seat.uid === meUid) return true;
+    if (meProfileId && seat.playerId === meProfileId) return true;
+    if (!seat.playerId && seat.uid === meUid) return true;
+    return false;
+  };
+
+  const resolveSeatName = (seat?: SeatEntry) => {
+    if (!seat) return "Empty";
+    const match = presence.find((entry) => {
+      if (seat.playerId && entry.profileId && entry.profileId === seat.playerId) {
+        return true;
+      }
+      return entry.playerId === seat.uid || entry.authUid === seat.uid;
+    });
+    const base = match?.codename ?? seat.playerId ?? seat.uid;
+    return base || "Agent";
+  };
+
+  const hostSeat = seatMap.get(0);
+  const remoteSeat = seatMap.get(1);
+  const isHost = !!hostSeat && isSeatMine(hostSeat);
+
+  const hostLabel = hostSeat ? `${resolveSeatName(hostSeat)}${isSeatMine(hostSeat) ? " (you)" : ""}` : "open";
+  const remoteLabel = remoteSeat
+    ? `${resolveSeatName(remoteSeat)}${isSeatMine(remoteSeat) ? " (you)" : ""}`
+    : "open";
+
   const debugFooter = useMemo(() => {
     const tick = state?.tick ?? 0;
     const playersCount = chipNames.length;
-    return `tick=${tick} · agents=${playersCount} · ready=${stateReady}`;
-  }, [chipNames.length, state?.tick, stateReady]);
+    return `tick=${tick} · agents=${playersCount} · host=${hostLabel} · p2=${remoteLabel} · ready=${stateReady}`;
+  }, [chipNames.length, hostLabel, remoteLabel, state?.tick, stateReady]);
+
+  const handleJoinSeat = async (seatNo: number) => {
+    if (!arenaId || !meUid) return;
+    setSeatBusy(seatNo);
+    setSeatMessage(null);
+    try {
+      await claimArenaSeat(arenaId, seatNo, { uid: meUid, playerId: meProfileId });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to join seat.";
+      setSeatMessage(message);
+    } finally {
+      setSeatBusy(null);
+    }
+  };
+
+  const handleLeaveSeat = async (seatNo: number) => {
+    if (!arenaId || !meUid) return;
+    setSeatBusy(seatNo);
+    setSeatMessage(null);
+    try {
+      await releaseArenaSeat(arenaId, seatNo, { uid: meUid, playerId: meProfileId });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to leave seat.";
+      setSeatMessage(message);
+    } finally {
+      setSeatBusy(null);
+    }
+  };
+
+  useEffect(() => {
+    if (!isHost || !arenaId || !meUid || !canvasRef.current) {
+      if (gameRef.current) {
+        console.info("[ARENA] tearing down Phaser host", { arenaId });
+        gameRef.current.destroy(true);
+        gameRef.current = null;
+      }
+      return;
+    }
+
+    const codename = player?.codename ?? meUid.slice(0, 6);
+    const spawn = { x: 240, y: 360 };
+    const canvasEl = canvasRef.current;
+    if (!canvasEl) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await initArenaPlayerState(arenaId, { id: meUid, codename }, spawn);
+        if (cancelled) return;
+        const config: Phaser.Types.Core.GameConfig = {
+          type: Phaser.AUTO,
+          width: 960,
+          height: 540,
+          parent: canvasEl,
+          backgroundColor: "#0f1115",
+          physics: { default: "arcade", arcade: { gravity: { x: 0, y: 900 }, debug: false } },
+          scene: [],
+        };
+        const game = makeGame(config);
+        game.scene.add(
+          "Arena",
+          ArenaScene,
+          true,
+          {
+            arenaId,
+            me: { id: meUid, codename },
+            spawn,
+          },
+        );
+        gameRef.current = game;
+      } catch (err) {
+        if (cancelled) return;
+        console.error("[ARENA] failed to boot Phaser host", err);
+        setSeatMessage((prev) => prev ?? "Failed to start local host session.");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (gameRef.current) {
+        console.info("[ARENA] destroying Phaser host", { arenaId });
+        gameRef.current.destroy(true);
+        gameRef.current = null;
+      }
+    };
+  }, [arenaId, isHost, meUid, player?.codename]);
+
+  useEffect(() => {
+    if (!arenaId || !meUid) return;
+    const identity = { uid: meUid, playerId: meProfileId };
+    return () => {
+      releaseArenaSeat(arenaId, 0, identity).catch((err) => console.warn("[ARENA] release seat0 failed", err));
+      releaseArenaSeat(arenaId, 1, identity).catch((err) => console.warn("[ARENA] release seat1 failed", err));
+    };
+  }, [arenaId, meProfileId, meUid]);
 
   return (
     <div className="grid" style={{ gap: 24 }}>
@@ -217,6 +371,60 @@ export default function ArenaPage() {
       </section>
 
       <section className="card card-canvas">
+        <div className="grid" style={{ gap: 12, marginBottom: 12 }}>
+          {[0, 1].map((seatNo) => {
+            const seat = seatMap.get(seatNo);
+            const mine = isSeatMine(seat);
+            const label = seatNo === 0 ? "Player 1 (Host)" : "Player 2";
+            const occupied = !!seat;
+            const name = resolveSeatName(seat);
+            const disabled = seatBusy !== null || !meUid || (occupied && !mine) || seatsLoading;
+            return (
+              <div key={seatNo} className="card" style={{ margin: 0, padding: 12 }}>
+                <div className="muted mono" style={{ marginBottom: 4 }}>{label}</div>
+                <div style={{ fontFamily: "var(--font-mono)", marginBottom: 12 }}>
+                  {occupied ? (
+                    <>
+                      {name}
+                      {mine ? " (you)" : ""}
+                    </>
+                  ) : (
+                    <span className="muted">Open seat</span>
+                  )}
+                </div>
+                <div className="button-row">
+                  {mine ? (
+                    <button
+                      type="button"
+                      className="button ghost"
+                      onClick={() => handleLeaveSeat(seatNo)}
+                      disabled={seatBusy === seatNo}
+                    >
+                      {seatBusy === seatNo ? "Leaving…" : "Leave seat"}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="button"
+                      onClick={() => handleJoinSeat(seatNo)}
+                      disabled={disabled}
+                    >
+                      {seatBusy === seatNo ? "Joining…" : `Join P${seatNo + 1}`}
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        {seatMessage ? (
+          <div className="error" style={{ marginBottom: 12 }}>{seatMessage}</div>
+        ) : null}
+        {seatsError ? (
+          <div className="error" style={{ marginBottom: 12 }}>
+            Failed to load seat assignments.
+          </div>
+        ) : null}
         <div
           ref={canvasRef}
           className="canvas-frame"
@@ -227,9 +435,13 @@ export default function ArenaPage() {
             placeItems: "center",
           }}
         >
-          <div className="muted" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-sm)" }}>
-            Phaser canvas bootstraps here.
-          </div>
+          {!isHost ? (
+            <div className="muted" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-sm)", textAlign: "center" }}>
+              {hostSeat
+                ? `Host: ${resolveSeatName(hostSeat)} · Claim Player 1 to take control.`
+                : "Claim Player 1 to launch the local host."}
+            </div>
+          ) : null}
         </div>
         <div className="card-footer">[NET] {debugFooter}</div>
       </section>

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -28,6 +28,13 @@ export interface ArenaPresenceEntry {
   profileId?: string;
 }
 
+export interface ArenaSeatAssignment {
+  seatNo: number;
+  playerId: string;
+  uid: string;
+  joinedAt?: string;
+}
+
 export interface LeaderboardEntry {
   id: string;
   playerId: string;

--- a/src/utils/useArenaSeats.ts
+++ b/src/utils/useArenaSeats.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import type { FirestoreError, Unsubscribe } from "firebase/firestore";
+import { ensureAnonAuth, watchArenaSeats } from "../firebase";
+import type { ArenaSeatAssignment } from "../types/models";
+
+interface UseArenaSeatsResult {
+  seats: ArenaSeatAssignment[];
+  loading: boolean;
+  error: FirestoreError | null;
+}
+
+export function useArenaSeats(arenaId?: string): UseArenaSeatsResult {
+  const [seats, setSeats] = useState<ArenaSeatAssignment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<FirestoreError | null>(null);
+
+  useEffect(() => {
+    if (!arenaId) {
+      setSeats([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let unsub: Unsubscribe | undefined;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        await ensureAnonAuth();
+        if (cancelled) return;
+        unsub = watchArenaSeats(arenaId, (entries) => {
+          if (cancelled) return;
+          setSeats(entries);
+          setLoading(false);
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setError(err as FirestoreError);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unsub?.();
+    };
+  }, [arenaId]);
+
+  return { seats, loading, error };
+}


### PR DESCRIPTION
## Summary
- add Firestore seat helpers with exclusive claim/release logic and live subscriptions
- expose new arena seat hook and UI controls so players can join or leave Player 1/Player 2 slots
- launch/destroy the Phaser arena host only when occupying seat 0 while seat 1 stays remote-controlled

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfb7708854832eb34d1f3aaf4102e4