### PR TITLE
Add touch control overlay and input channel

### DIFF
--- a/src/game/input/KeyBinder.ts
+++ b/src/game/input/KeyBinder.ts
@@ -1,36 +1,132 @@
-export type KeyState = { left: boolean; right: boolean; up: boolean; jump: boolean; attack: boolean; seq: number };
+import {
+  clearInputSource,
+  createInputSource,
+  type InputState,
+  type InputSource,
+  updateInputSource,
+} from "./inputsChannel";
+
+export type KeyState = {
+  left: boolean;
+  right: boolean;
+  up: boolean;
+  jump: boolean;
+  attack1: boolean;
+  attack2: boolean;
+  seq: number;
+};
+
+type MutableState = Omit<KeyState, "seq">;
+
+function toPartialUpdate(key: keyof MutableState, value: boolean): Partial<InputState> {
+  switch (key) {
+    case "left":
+    case "right":
+    case "attack1":
+    case "attack2":
+      return { [key]: value } as Partial<InputState>;
+    case "up":
+      return { up: value };
+    case "jump":
+      return { jump: value };
+    default:
+      return {};
+  }
+}
 
 export function createKeyBinder(target: Window = window) {
-  const state: KeyState = { left: false, right: false, up: false, jump: false, attack: false, seq: 0 };
-  const set = (k: keyof KeyState, v: boolean) => {
-    if ((state as any)[k] !== v) {
-      (state as any)[k] = v;
-      state.seq++;
-    }
+  const source: InputSource = createInputSource("keyboard");
+  const state: KeyState = {
+    left: false,
+    right: false,
+    up: false,
+    jump: false,
+    attack1: false,
+    attack2: false,
+    seq: 0,
   };
+
+  const set = (k: keyof MutableState, v: boolean) => {
+    if (state[k] === v) {
+      return;
+    }
+    state[k] = v;
+    state.seq += 1;
+    const update = toPartialUpdate(k, v);
+    if (k === "up") {
+      update.jump = v;
+    } else if (k === "jump") {
+      update.jump = v;
+    }
+    updateInputSource(source, update);
+  };
+
   const down = (e: KeyboardEvent) => {
     switch (e.code) {
-      case "KeyA": set("left", true); break;
-      case "KeyD": set("right", true); break;
-      case "KeyW": set("up", true); set("jump", true); break;
-      case "Space": set("jump", true); break;
-      case "KeyJ": set("attack", true); break;
+      case "KeyA":
+      case "ArrowLeft":
+        set("left", true);
+        break;
+      case "KeyD":
+      case "ArrowRight":
+        set("right", true);
+        break;
+      case "KeyW":
+      case "ArrowUp":
+        set("up", true);
+        set("jump", true);
+        break;
+      case "Space":
+        set("jump", true);
+        break;
+      case "KeyJ":
+        set("attack1", true);
+        break;
+      case "KeyK":
+        set("attack2", true);
+        break;
+      default:
+        break;
     }
   };
+
   const up = (e: KeyboardEvent) => {
     switch (e.code) {
-      case "KeyA": set("left", false); break;
-      case "KeyD": set("right", false); break;
-      case "KeyW": set("up", false); set("jump", false); break;
-      case "Space": set("jump", false); break;
-      case "KeyJ": set("attack", false); break;
+      case "KeyA":
+      case "ArrowLeft":
+        set("left", false);
+        break;
+      case "KeyD":
+      case "ArrowRight":
+        set("right", false);
+        break;
+      case "KeyW":
+      case "ArrowUp":
+        set("up", false);
+        set("jump", false);
+        break;
+      case "Space":
+        set("jump", false);
+        break;
+      case "KeyJ":
+        set("attack1", false);
+        break;
+      case "KeyK":
+        set("attack2", false);
+        break;
+      default:
+        break;
     }
   };
+
   target.addEventListener("keydown", down);
   target.addEventListener("keyup", up);
+
   const dispose = () => {
     target.removeEventListener("keydown", down);
     target.removeEventListener("keyup", up);
+    clearInputSource(source);
   };
+
   return { state, dispose };
 }

--- a/src/game/input/TouchControls.tsx
+++ b/src/game/input/TouchControls.tsx
@@ -1,0 +1,263 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  clearInputSource,
+  createInputSource,
+  type InputSource,
+  type InputState,
+  updateInputSource,
+} from "./inputsChannel";
+
+type TouchKey = "left" | "right" | "up" | "attack1" | "attack2";
+
+type ActiveMap = Record<TouchKey, boolean>;
+
+type PointerBuckets = Record<TouchKey, Set<number>>;
+
+function createPointerBuckets(): PointerBuckets {
+  return {
+    left: new Set<number>(),
+    right: new Set<number>(),
+    up: new Set<number>(),
+    attack1: new Set<number>(),
+    attack2: new Set<number>(),
+  };
+}
+
+const ORIENTATION_QUERY = "(orientation: portrait)";
+
+function getOrientation(): "portrait" | "landscape" {
+  if (typeof window === "undefined") {
+    return "landscape";
+  }
+  const query = window.matchMedia?.(ORIENTATION_QUERY);
+  if (query) {
+    return query.matches ? "portrait" : "landscape";
+  }
+  return window.innerHeight >= window.innerWidth ? "portrait" : "landscape";
+}
+
+const baseActiveMap: ActiveMap = {
+  left: false,
+  right: false,
+  up: false,
+  attack1: false,
+  attack2: false,
+};
+
+const TouchControls: React.FC = () => {
+  const sourceRef = useRef<InputSource>(createInputSource("touch-controls"));
+  const pointersRef = useRef<PointerBuckets>(createPointerBuckets());
+  const [activeMap, setActiveMap] = useState<ActiveMap>({ ...baseActiveMap });
+  const [orientation, setOrientation] = useState<"portrait" | "landscape">(getOrientation);
+
+  const updateOrientation = useCallback(() => {
+    setOrientation(getOrientation());
+  }, []);
+
+  useEffect(() => {
+    const query = typeof window !== "undefined" ? window.matchMedia?.(ORIENTATION_QUERY) : null;
+    if (query?.addEventListener) {
+      query.addEventListener("change", updateOrientation);
+    } else if (query?.addListener) {
+      query.addListener(updateOrientation);
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", updateOrientation);
+      window.addEventListener("orientationchange", updateOrientation);
+    }
+    return () => {
+      if (query?.removeEventListener) {
+        query.removeEventListener("change", updateOrientation);
+      } else if (query?.removeListener) {
+        query.removeListener(updateOrientation);
+      }
+      if (typeof window !== "undefined") {
+        window.removeEventListener("resize", updateOrientation);
+        window.removeEventListener("orientationchange", updateOrientation);
+      }
+    };
+  }, [updateOrientation]);
+
+  const releaseAll = useCallback(() => {
+    const source = sourceRef.current;
+    if (!source) {
+      return;
+    }
+    const partial: Partial<InputState> = {
+      left: false,
+      right: false,
+      up: false,
+      jump: false,
+      attack1: false,
+      attack2: false,
+    };
+    updateInputSource(source, partial);
+    pointersRef.current = createPointerBuckets();
+    setActiveMap({ ...baseActiveMap });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      releaseAll();
+      clearInputSource(sourceRef.current);
+    };
+  }, [releaseAll]);
+
+  const setPointerActive = useCallback(
+    (key: TouchKey, pointerId: number, active: boolean) => {
+      const source = sourceRef.current;
+      const buckets = pointersRef.current;
+      const bucket = buckets[key];
+      if (active) {
+        bucket.add(pointerId);
+      } else {
+        bucket.delete(pointerId);
+      }
+      const nextActive = bucket.size > 0;
+      setActiveMap((prev) => {
+        if (prev[key] === nextActive) {
+          return prev;
+        }
+        return { ...prev, [key]: nextActive };
+      });
+      if (!source) {
+        return;
+      }
+      switch (key) {
+        case "left":
+        case "right":
+        case "attack1":
+        case "attack2": {
+          updateInputSource(source, { [key]: nextActive } as Partial<InputState>);
+          break;
+        }
+        case "up": {
+          updateInputSource(source, { up: nextActive, jump: nextActive });
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [],
+  );
+
+  const makePointerHandler = useCallback(
+    (key: TouchKey, active: boolean) =>
+      (event: React.PointerEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (active) {
+          event.currentTarget.setPointerCapture?.(event.pointerId);
+        } else {
+          event.currentTarget.releasePointerCapture?.(event.pointerId);
+        }
+        setPointerActive(key, event.pointerId, active);
+      },
+    [setPointerActive],
+  );
+
+  const handleCancel = useCallback(
+    (key: TouchKey) => (event: React.PointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+      setPointerActive(key, event.pointerId, false);
+    },
+    [setPointerActive],
+  );
+
+  const buttonClass = useCallback(
+    (key: TouchKey, extra?: string) => {
+      const classes = ["touch-controls__button"];
+      if (extra) {
+        classes.push(extra);
+      }
+      if (activeMap[key]) {
+        classes.push("touch-controls__button--active");
+      }
+      return classes.join(" ");
+    },
+    [activeMap],
+  );
+
+  const orientationClass = useMemo(() => {
+    return orientation === "portrait" ? "touch-controls--portrait" : "touch-controls--landscape";
+  }, [orientation]);
+
+  return (
+    <div className={`touch-controls ${orientationClass}`}>
+      <div className="touch-controls__group">
+        <div className="touch-controls__dpad">
+          <span />
+          <button
+            type="button"
+            className={buttonClass("up", "touch-controls__button--dpad")}
+            onPointerDown={makePointerHandler("up", true)}
+            onPointerUp={makePointerHandler("up", false)}
+            onPointerCancel={handleCancel("up")}
+            onLostPointerCapture={handleCancel("up")}
+            onContextMenu={(event) => event.preventDefault()}
+            aria-label="Jump"
+          >
+            ↑
+          </button>
+          <span />
+          <button
+            type="button"
+            className={buttonClass("left", "touch-controls__button--dpad")}
+            onPointerDown={makePointerHandler("left", true)}
+            onPointerUp={makePointerHandler("left", false)}
+            onPointerCancel={handleCancel("left")}
+            onLostPointerCapture={handleCancel("left")}
+            onContextMenu={(event) => event.preventDefault()}
+            aria-label="Move left"
+          >
+            ←
+          </button>
+          <span />
+          <button
+            type="button"
+            className={buttonClass("right", "touch-controls__button--dpad")}
+            onPointerDown={makePointerHandler("right", true)}
+            onPointerUp={makePointerHandler("right", false)}
+            onPointerCancel={handleCancel("right")}
+            onLostPointerCapture={handleCancel("right")}
+            onContextMenu={(event) => event.preventDefault()}
+            aria-label="Move right"
+          >
+            →
+          </button>
+        </div>
+      </div>
+      <div className="touch-controls__group touch-controls__attack-group">
+        <button
+          type="button"
+          className={buttonClass("attack1", "touch-controls__button--attack")}
+          onPointerDown={makePointerHandler("attack1", true)}
+          onPointerUp={makePointerHandler("attack1", false)}
+          onPointerCancel={handleCancel("attack1")}
+          onLostPointerCapture={handleCancel("attack1")}
+          onContextMenu={(event) => event.preventDefault()}
+          aria-label="Attack 1"
+        >
+          A
+        </button>
+        <button
+          type="button"
+          className={buttonClass("attack2", "touch-controls__button--attack")}
+          onPointerDown={makePointerHandler("attack2", true)}
+          onPointerUp={makePointerHandler("attack2", false)}
+          onPointerCancel={handleCancel("attack2")}
+          onLostPointerCapture={handleCancel("attack2")}
+          onContextMenu={(event) => event.preventDefault()}
+          aria-label="Attack 2"
+        >
+          B
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TouchControls;

--- a/src/game/input/inputsChannel.ts
+++ b/src/game/input/inputsChannel.ts
@@ -1,0 +1,144 @@
+import { publishInput } from "../../net/ActionBus";
+
+export type InputKey = "left" | "right" | "up" | "jump" | "attack1" | "attack2";
+
+export type InputState = Record<InputKey, boolean>;
+
+export type InputSnapshot = InputState & { seq: number };
+
+export type InputSource = symbol;
+
+type Listener = (snapshot: InputSnapshot) => void;
+
+const INPUT_KEYS: InputKey[] = ["left", "right", "up", "jump", "attack1", "attack2"];
+
+const INITIAL_STATE: InputState = {
+  left: false,
+  right: false,
+  up: false,
+  jump: false,
+  attack1: false,
+  attack2: false,
+};
+
+const sources = new Map<InputSource, InputState>();
+let aggregate: InputSnapshot = { ...INITIAL_STATE, seq: 0 };
+const listeners = new Set<Listener>();
+
+function cloneState(state: InputState): InputState {
+  return { ...state };
+}
+
+function computeAggregate(): InputState {
+  const next: InputState = { ...INITIAL_STATE };
+  for (const state of sources.values()) {
+    for (const key of INPUT_KEYS) {
+      if (state[key]) {
+        next[key] = true;
+      }
+    }
+  }
+  return next;
+}
+
+function emitIfChanged(next: InputState) {
+  let changed = false;
+  for (const key of INPUT_KEYS) {
+    if (aggregate[key] !== next[key]) {
+      changed = true;
+      break;
+    }
+  }
+  if (!changed) {
+    return;
+  }
+  aggregate = { ...next, seq: aggregate.seq + 1 };
+  const snapshot = { ...aggregate };
+  for (const listener of listeners) {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.warn("[inputs] listener error", error);
+    }
+  }
+  publishInput({
+    left: aggregate.left,
+    right: aggregate.right,
+    jump: aggregate.jump || aggregate.up,
+    attack: aggregate.attack1 || aggregate.attack2,
+  });
+}
+
+function ensureSource(source: InputSource): InputState {
+  const existing = sources.get(source);
+  if (existing) {
+    return existing;
+  }
+  const state = cloneState(INITIAL_STATE);
+  sources.set(source, state);
+  return state;
+}
+
+export function createInputSource(label?: string): InputSource {
+  const source: InputSource = Symbol(label ?? "input-source");
+  sources.set(source, cloneState(INITIAL_STATE));
+  return source;
+}
+
+export function updateInputSource(source: InputSource, partial: Partial<InputState>): void {
+  const current = ensureSource(source);
+  const next = { ...current };
+  let mutated = false;
+  for (const [key, value] of Object.entries(partial)) {
+    if (!INPUT_KEYS.includes(key as InputKey)) {
+      continue;
+    }
+    const typedKey = key as InputKey;
+    const boolValue = !!value;
+    if (next[typedKey] !== boolValue) {
+      next[typedKey] = boolValue;
+      mutated = true;
+    }
+  }
+  if (!mutated) {
+    return;
+  }
+  sources.set(source, next);
+  const aggregateNext = computeAggregate();
+  emitIfChanged(aggregateNext);
+}
+
+export function clearInputSource(source: InputSource): void {
+  if (!sources.has(source)) {
+    return;
+  }
+  sources.delete(source);
+  const aggregateNext = computeAggregate();
+  emitIfChanged(aggregateNext);
+}
+
+export function getInputSnapshot(): InputSnapshot {
+  return { ...aggregate };
+}
+
+export function subscribeInputs(listener: Listener): () => void {
+  listeners.add(listener);
+  listener({ ...aggregate });
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetInputs(): void {
+  aggregate = { ...INITIAL_STATE, seq: aggregate.seq + 1 };
+  sources.clear();
+  const snapshot = { ...aggregate };
+  for (const listener of listeners) {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.warn("[inputs] listener error", error);
+    }
+  }
+  publishInput({ left: false, right: false, jump: false, attack: false });
+}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -170,6 +170,10 @@ hr {
   overflow: hidden;
 }
 
+.canvas-frame {
+  position: relative;
+}
+
 .card-canvas > .canvas-frame {
   border-radius: var(--radius);
   overflow: hidden;
@@ -350,6 +354,123 @@ textarea:focus {
   height: 1rem;
   border-radius: 6px;
   animation: pulse 1.4s infinite ease-in-out;
+}
+
+/* Touch controls overlay */
+.touch-controls {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding: 16px;
+  gap: 16px;
+  pointer-events: none;
+  --touch-button-size: clamp(54px, 13vw, 88px);
+  --touch-attack-size: clamp(64px, 16vw, 104px);
+}
+
+.touch-controls__group {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.touch-controls__attack-group {
+  flex-direction: column;
+  align-items: center;
+}
+
+.touch-controls__dpad {
+  display: grid;
+  grid-template-columns: repeat(3, var(--touch-button-size));
+  grid-template-rows: repeat(3, var(--touch-button-size));
+  gap: 12px;
+  justify-items: center;
+  align-items: center;
+}
+
+.touch-controls__dpad > span {
+  width: var(--touch-button-size);
+  height: var(--touch-button-size);
+}
+
+.touch-controls__button {
+  width: var(--touch-button-size);
+  height: var(--touch-button-size);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  font-size: clamp(16px, 4vw, 22px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+  pointer-events: auto;
+  backdrop-filter: blur(8px);
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+}
+
+.touch-controls__button--attack {
+  width: var(--touch-attack-size);
+  height: var(--touch-attack-size);
+  font-size: clamp(18px, 5vw, 26px);
+}
+
+.touch-controls__button--active {
+  background: rgba(59, 130, 246, 0.82);
+  border-color: rgba(59, 130, 246, 0.95);
+  transform: scale(0.96);
+}
+
+.touch-controls--portrait {
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: stretch;
+}
+
+.touch-controls--portrait .touch-controls__group {
+  justify-content: center;
+}
+
+.touch-controls--portrait .touch-controls__attack-group {
+  flex-direction: row;
+  justify-content: center;
+}
+
+.touch-controls--landscape {
+  flex-direction: row;
+}
+
+.touch-controls--landscape .touch-controls__group:first-of-type {
+  justify-content: flex-start;
+}
+
+.touch-controls--landscape .touch-controls__attack-group {
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .touch-controls {
+    padding: 12px;
+    gap: 12px;
+    --touch-button-size: clamp(48px, 18vw, 76px);
+    --touch-attack-size: clamp(56px, 22vw, 92px);
+  }
+
+  .touch-controls__group {
+    gap: 12px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .touch-controls {
+    --touch-button-size: 80px;
+    --touch-attack-size: 98px;
+  }
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- add a shared inputs channel that merges keyboard/touch sources and forwards the combined state to the ActionBus
- build a touch control overlay with a virtual d-pad and dual attack buttons that publish into the shared channel
- surface the overlay in the arena for touch-capable browsers and add responsive styling for the controls

## Testing
- pnpm run typecheck *(fails: repo is missing net/matchChannel.ts, net/snapshotBuffer.ts and Player.setFacing/playAnim definitions referenced by ArenaScene)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc16eea44832eb05b0336925579dd