### PR TITLE
Track KO wins in leaderboard and surface arena standings

### DIFF
--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -43,4 +43,5 @@ export interface LeaderboardEntry {
   losses: number;
   streak: number;
   updatedAt: string;
+  lastWinAt?: string;
 }


### PR DESCRIPTION
## Summary
- add Firestore helpers to atomically record leaderboard wins, expose live subscriptions, and gate debug logging
- trigger win tracking from the host loop when a player is knocked out
- surface a live leaderboard card on the arena page for quick visibility into streaks and wins

## Testing
- `npm run typecheck` *(fails: project is missing ../net/matchChannel and related typings in ArenaScene.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1744a70832ebdd358f7a4348d27