### PR TITLE
Tighten arena input and seat rules

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -42,6 +42,8 @@ This report enumerates the gaps between the current lobby scaffold and the "From
   4. Add a Cloud Function (or local emulator script) that watches finished matches and cleans up `/arenas/*` subcollections.
 
 ## E. Networking Skeleton and Authoritative Transport
+- **Updates**
+  - Locked down Firestore arena input and seat documents so only authenticated owners can write, covering the brief's security gap for seat-bound input publishing.
 - **Missing components / files**
   - `src/net/ActionBus.ts` exists but is not wired into the arena scene or battle reducer; there is no reconciliation layer between Firestore actions and the simulation history in `src/sim`.
   - No deterministic snapshot/rollback service; `src/sim/reducer.ts` runs locally only.

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,8 @@
 {
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
   "hosting": {
     "public": "dist",
     "ignore": ["firebase.json","**/.*","**/node_modules/**"],

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,6 +11,20 @@ service cloud.firestore {
       allow read: if isSignedIn();
       allow write: if isSignedIn();
 
+      match /inputs/{uid} {
+        allow read: if isSignedIn();
+        allow write: if isSignedIn() && request.auth.uid == uid;
+      }
+
+      match /seats/{seatNo} {
+        allow read: if isSignedIn();
+        allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+        allow update: if isSignedIn()
+          && resource.data.uid == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow delete: if isSignedIn() && resource.data.uid == request.auth.uid;
+      }
+
       // Presence subcollection (existing)
       match /presence/{playerId} {
         allow read, write: if isSignedIn();


### PR DESCRIPTION
## Summary
- restrict arena input documents so only authenticated owners can write while keeping reads open to signed-in players
- add seat subcollection rules enforcing owner-only creates, updates, and deletes
- hook the firestore rules into firebase.json and log the security hardening in the gap analysis

## Testing
- not run (rules/config change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfc17a415c832e8977be0ae3b4f67b