### PR TITLE
Refactor arena runtime hook and clean debug logging

### DIFF
--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -217,6 +217,23 @@ export class Player extends Phaser.Events.EventEmitter {
     this.updateRigVisual();
   }
 
+  setFacing(direction: "L" | "R") {
+    const next = direction === "L" ? -1 : 1;
+    if (this.facing === next) {
+      return;
+    }
+    this.facing = next;
+    const attackBody = this.attackHitbox.body as Phaser.Physics.Arcade.Body;
+    const hitboxX = this.sprite.x + this.facing * ATTACK_OFFSET;
+    attackBody.reset(hitboxX, this.sprite.y);
+    this.attackHitbox.setPosition(hitboxX, this.sprite.y);
+    this.updateRigVisual();
+  }
+
+  playAnim(anim: string) {
+    this.updateRigVisual({ isAttacking: anim === "attack" });
+  }
+
   private startAttack() {
     this.attackTimer = ATTACK_DURATION;
     this.attackCooldown = ATTACK_COOLDOWN;

--- a/src/game/net/matchChannel.ts
+++ b/src/game/net/matchChannel.ts
@@ -1,0 +1,66 @@
+import { createArenaPeerService, type ArenaPeerService, type ArenaStateSnapshot } from "./arenaSync";
+
+export type AuthoritativeSnapshot = ArenaStateSnapshot;
+
+export type MatchRole = "host" | "peer";
+export type MatchSeat = "A" | "B";
+
+export interface MatchChannel {
+  publishInputs(payload: Record<string, unknown>): void;
+  onSnapshot(cb: (snapshot: AuthoritativeSnapshot | undefined) => void): () => void;
+  onRoleChange?(cb: (role: MatchRole) => void): () => void;
+  onSeatChange?(cb: (seat: MatchSeat | undefined) => void): () => void;
+  destroy(): void;
+}
+
+interface CreateMatchChannelOptions {
+  arenaId: string;
+}
+
+export function createMatchChannel(options: CreateMatchChannelOptions): MatchChannel {
+  const peer: ArenaPeerService = createArenaPeerService({ arenaId: options.arenaId });
+  const snapshotListeners = new Set<(snapshot: AuthoritativeSnapshot | undefined) => void>();
+  let unsubscribe: (() => void) | null = null;
+
+  const ensureSubscribed = () => {
+    if (unsubscribe) return;
+    unsubscribe = peer.subscribe((snapshot) => {
+      snapshotListeners.forEach((listener) => {
+        listener(snapshot);
+      });
+    });
+  };
+
+  return {
+    publishInputs() {
+      // Networking bridge not yet implemented; clients rely on peer snapshots only.
+    },
+    onSnapshot(cb) {
+      snapshotListeners.add(cb);
+      ensureSubscribed();
+      return () => {
+        snapshotListeners.delete(cb);
+        if (snapshotListeners.size === 0 && unsubscribe) {
+          unsubscribe();
+          unsubscribe = null;
+        }
+      };
+    },
+    onRoleChange(cb) {
+      cb("peer");
+      return () => undefined;
+    },
+    onSeatChange(cb) {
+      cb(undefined);
+      return () => undefined;
+    },
+    destroy() {
+      if (unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
+      snapshotListeners.clear();
+      peer.destroy();
+    },
+  };
+}

--- a/src/game/net/snapshotBuffer.ts
+++ b/src/game/net/snapshotBuffer.ts
@@ -1,0 +1,29 @@
+export type SnapshotEntry<T> = {
+  snapshot: T;
+  timestamp: number;
+};
+
+export class SnapshotBuffer<T> {
+  private entries: SnapshotEntry<T>[] = [];
+
+  constructor(private readonly maxEntries = 4) {}
+
+  push(snapshot: T, timestamp: number): void {
+    this.entries.push({ snapshot, timestamp });
+    this.entries.sort((a, b) => a.timestamp - b.timestamp);
+    while (this.entries.length > this.maxEntries) {
+      this.entries.shift();
+    }
+  }
+
+  getInterpolated(_now: number): T | undefined {
+    if (this.entries.length === 0) {
+      return undefined;
+    }
+    return this.entries[this.entries.length - 1]!.snapshot;
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+}

--- a/src/utils/useArenaRuntime.ts
+++ b/src/utils/useArenaRuntime.ts
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Phaser from "phaser";
+
+import { initArenaPlayerState } from "../firebase";
+import { makeGame } from "../game/phaserGame";
+import ArenaScene, { type ArenaSceneConfig } from "../game/arena/ArenaScene";
+import { startHostLoop, type HostLoopController } from "../game/net/hostLoop";
+import { disposeActionBus } from "../net/ActionBus";
+
+const DEBUG = import.meta.env.DEV && import.meta.env.VITE_DEBUG_ARENA_PAGE === "true";
+
+export interface UseArenaRuntimeOptions {
+  arenaId?: string;
+  authReady: boolean;
+  stateReady: boolean;
+  isHost: boolean;
+  meUid?: string | null;
+  codename?: string | null;
+  canvasRef: React.RefObject<HTMLDivElement | null>;
+  onBootError?: (message: string) => void;
+}
+
+export interface UseArenaRuntimeResult {
+  gameBooted: boolean;
+}
+
+function destroyGame(game: Phaser.Game | null) {
+  if (!game) return;
+  try {
+    game.destroy(true);
+  } catch (error) {
+    if (DEBUG) {
+      console.warn("[ARENA] error destroying Phaser game", error);
+    }
+  }
+}
+
+export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntimeResult {
+  const { arenaId, authReady, stateReady, isHost, meUid, codename, canvasRef, onBootError } = options;
+
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const [gameBooted, setGameBooted] = useState(false);
+
+  const teardown = useCallback(() => {
+    const cleanup = cleanupRef.current;
+    cleanupRef.current = null;
+    if (cleanup) {
+      try {
+        cleanup();
+      } catch (error) {
+        if (DEBUG) {
+          console.warn("[ARENA] runtime cleanup failed", error);
+        }
+      }
+    } else if (gameRef.current) {
+      destroyGame(gameRef.current);
+      gameRef.current = null;
+    }
+
+    disposeActionBus();
+    setGameBooted(false);
+  }, []);
+
+  useEffect(() => teardown, [teardown]);
+
+  const shouldBoot = useMemo(() => {
+    return Boolean(arenaId && authReady && stateReady && meUid);
+  }, [arenaId, authReady, stateReady, meUid]);
+
+  useEffect(() => {
+    if (!shouldBoot) {
+      teardown();
+      return;
+    }
+
+    const canvasEl = canvasRef.current;
+    if (!canvasEl) {
+      teardown();
+      return;
+    }
+
+    let cancelled = false;
+    const disposers: Array<() => void> = [];
+
+    const boot = async () => {
+      const playerId = meUid!;
+      const playerCodename = codename ?? playerId.slice(0, 6);
+      const spawn = { x: 240, y: 540 - 40 - 60 };
+
+      try {
+        if (isHost) {
+          if (DEBUG) {
+            console.info("[ARENA] host bootstrap starting", { arenaId, playerId });
+          }
+          await initArenaPlayerState(arenaId!, { id: playerId, codename: playerCodename }, spawn);
+          if (cancelled) {
+            return;
+          }
+
+          const controller: HostLoopController = startHostLoop({
+            arenaId: arenaId!,
+            hostId: playerId,
+            log: DEBUG ? console : undefined,
+          });
+          disposers.push(() => controller.stop());
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        const config: Phaser.Types.Core.GameConfig = {
+          type: Phaser.AUTO,
+          width: 960,
+          height: 540,
+          parent: canvasEl,
+          backgroundColor: "#0f1115",
+          physics: {
+            default: "arcade",
+            arcade: { gravity: { x: 0, y: 900 }, debug: false },
+          },
+          scene: [],
+        };
+
+        const game = makeGame(config);
+        gameRef.current = game;
+
+        const sceneConfig: ArenaSceneConfig = {
+          arenaId: arenaId!,
+          me: { id: playerId, codename: playerCodename },
+          spawn,
+          isHostClient: isHost,
+        };
+
+        game.scene.add("Arena", ArenaScene, true, sceneConfig);
+        setGameBooted(true);
+
+        cleanupRef.current = () => {
+          for (let i = disposers.length - 1; i >= 0; i -= 1) {
+            const dispose = disposers[i];
+            try {
+              dispose();
+            } catch (error) {
+              if (DEBUG) {
+                console.warn("[ARENA] runtime disposer failed", error);
+              }
+            }
+          }
+
+          if (gameRef.current === game) {
+            gameRef.current = null;
+          }
+          destroyGame(game);
+        };
+      } catch (error) {
+        teardown();
+        if (!cancelled) {
+          if (DEBUG) {
+            console.error("[ARENA] failed to boot runtime", error);
+          }
+          onBootError?.("Failed to start local host session.");
+        }
+      }
+    };
+
+    void boot();
+
+    return () => {
+      cancelled = true;
+      teardown();
+    };
+  }, [arenaId, canvasRef, codename, isHost, meUid, onBootError, shouldBoot, teardown]);
+
+  return { gameBooted };
+}
+


### PR DESCRIPTION
## Summary
- add a useArenaRuntime hook that mounts Phaser, starts the host loop when needed, and tears everything down cleanly
- wire ArenaPage to the new hook and gate verbose console output behind a DEBUG flag
- provide lightweight match channel and snapshot buffer helpers while adapting ArenaScene and Player to the new snapshot shape

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfc17fa3b0832e92e86f7bdc4b5460