### PR TITLE
Import debug logging helpers in arena page

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -14,6 +14,7 @@ import {
   type LeaderboardEntry,
 } from "../firebase";
 } from "../firebase";
+import { debugLog, debugWarn } from "../net/debug";
 import {
   ensureArenaState,
   watchArenaState,


### PR DESCRIPTION
## Summary
- add explicit import for the debugLog/debugWarn helpers in the arena page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d033132dd4832eb1f39c40fd46e576