### PR TITLE
Improve arena identity handling

### DIFF
--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -33,6 +33,9 @@ export interface ArenaSeatAssignment {
   playerId: string;
   uid: string;
   joinedAt?: string;
+  profileId?: string;
+  codename?: string | null;
+  displayName?: string | null;
 }
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
## Summary
- ensure arena presence entries prefer the player profile id while keeping the auth uid recorded
- persist profile and codename metadata on seat assignments and use it when rendering player chips

## Testing
- npm run typecheck *(fails: existing ArenaPage.tsx debug helpers and useArenaRuntime import are still missing upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68d0332118ec832ea345b24ee8eafbaf