### PR TITLE
Fetch arena metadata for arena title display

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -31,6 +31,8 @@ This report enumerates the gaps between the current lobby scaffold and the "From
   3. Update security rules to scope write access to a player's own ticket and seat documents.
 
 ## D. Arena Session Lifecycle and State Persistence
+- **Updates**
+  - Arena page title now subscribes to arena metadata via `useArenaMeta`, logging the resolved label and warning if the Firestore document is missing while falling back to the generic "Arena" title.
 - **Missing components / files**
   - `src/pages/ArenaPage.tsx` still renders debug state instead of the Phaser scene; there is no match lifecycle (warmup, rounds, post-match) coordinator.
   - `src/lib/arenaState.ts` stores minimal HP/tick info and lacks structures for rounds, timers, or authoritative refs.

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -27,6 +27,7 @@ import { useArenaSeats } from "../utils/useArenaSeats";
 import { useAuth } from "../context/AuthContext";
 import TouchControls from "../game/input/TouchControls";
 import { useArenaRuntime } from "../utils/useArenaRuntime";
+import { useArenaMeta } from "../utils/useArenaMeta";
 
 // Optional: keep a gated warn helper (don’t also import debugWarn)
 const debugWarn = (...args: unknown[]) => {
@@ -50,11 +51,27 @@ export default function ArenaPage() {
 
   const { players: presence, loading: presenceLoading, error: presenceError } = useArenaPresence(arenaId);
   const { seats, loading: seatsLoading, error: seatsError } = useArenaSeats(arenaId);
+  const { arenaName, loading: arenaMetaLoading } = useArenaMeta(arenaId);
   const { user, player, authReady } = useAuth();
   const [seatBusy, setSeatBusy] = useState<number | null>(null);
   const [seatMessage, setSeatMessage] = useState<string | null>(null);
+  const titleLoggedRef = useRef(false);
+
+  const arenaTitle = arenaName ?? "Arena";
 
   type SeatEntry = (typeof seats)[number];
+
+  useEffect(() => {
+    titleLoggedRef.current = false;
+  }, [arenaId]);
+
+  useEffect(() => {
+    if (!arenaId) return;
+    if (arenaMetaLoading) return;
+    if (titleLoggedRef.current) return;
+    console.log(`[ARENA] title="${arenaTitle}" id=${arenaId}`);
+    titleLoggedRef.current = true;
+  }, [arenaId, arenaMetaLoading, arenaTitle]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -381,7 +398,7 @@ export default function ArenaPage() {
         <div className="card-header">
           <div className="meta-grid">
             <span className="muted mono">Arena</span>
-            <h2 style={{ margin: 0 }}>{arenaId || "Arena"}</h2>
+            <h2 style={{ margin: 0 }}>{arenaTitle}</h2>
           </div>
           <div className="button-row">
             <button type="button" className="button ghost" onClick={() => nav("/")}>

--- a/src/utils/useArenaMeta.ts
+++ b/src/utils/useArenaMeta.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { doc, onSnapshot, type FirestoreError, type Unsubscribe } from "firebase/firestore";
+
+import { db } from "../firebase";
+
+interface UseArenaMetaResult {
+  arenaName: string | null;
+  loading: boolean;
+  error: FirestoreError | null;
+}
+
+export function useArenaMeta(arenaId?: string): UseArenaMetaResult {
+  const [arenaName, setArenaName] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(() => Boolean(arenaId));
+  const [error, setError] = useState<FirestoreError | null>(null);
+
+  useEffect(() => {
+    if (!arenaId) {
+      setArenaName(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let unsub: Unsubscribe | undefined;
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+    setArenaName(null);
+
+    const arenaRef = doc(db, "arenas", arenaId);
+
+    unsub = onSnapshot(
+      arenaRef,
+      (snapshot) => {
+        if (cancelled) {
+          return;
+        }
+        setLoading(false);
+        if (!snapshot.exists()) {
+          console.warn(`[ARENA] metadata missing id=${arenaId}`);
+          setArenaName(null);
+          return;
+        }
+        const data = snapshot.data() as { name?: unknown } | undefined;
+        const name = typeof data?.name === "string" && data.name.trim().length > 0 ? data.name : null;
+        setArenaName(name);
+      },
+      (err) => {
+        if (cancelled) {
+          return;
+        }
+        setError(err);
+        setLoading(false);
+      }
+    );
+
+    return () => {
+      cancelled = true;
+      unsub?.();
+    };
+  }, [arenaId]);
+
+  return { arenaName, loading, error };
+}


### PR DESCRIPTION
## Summary
- add a `useArenaMeta` hook that listens to Firestore arena metadata and falls back to the default title when missing
- update `ArenaPage` to render the resolved arena title and log it once metadata loads
- document the arena title metadata fix in `REPORT.md`

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d03bdf6b9c832e8d09f36dc0345fb4