### PR TITLE
Remove seat UI and auto-select host from presence

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -66,6 +66,9 @@ This report enumerates the gaps between the current lobby scaffold and the "From
   4. Add unit tests in `src/sim/__tests__/` covering KO, respawn, and rollback recovery to guard deterministic behavior.
 
 ## G. Seats, Controls, and Input Abstraction
+- **Updates**
+  - Legacy seat gating kept the arena host loop tied to `/seats` documents, so presence-only clients never promoted a host when those docs were absent.
+  - Seatless auto-join now hides the seat UI, promotes the earliest presence entry to host, and boots the Phaser session as soon as auth and arena state resolve.
 - **Missing components / files**
   - Input binding lives in `src/game/input/keys.ts` and is tailored for the training sandbox, not match seats.
   - No concept of seat slots (e.g., `seatA`, `seatB`) to map devices to players.


### PR DESCRIPTION
## Summary
- remove the arena seat claims UI and log the new seatless mode while showing runtime errors inline
- refactor the arena runtime to choose the host from presence data and manage the host loop independently
- document the legacy seat root cause and the seatless auto-join fix in REPORT.md

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03bea7f58832e89c56dfaf52d92c6