### PR TITLE
Wire action bus and input handling

### DIFF
--- a/src/game/input/KeyBinder.ts
+++ b/src/game/input/KeyBinder.ts
@@ -62,6 +62,10 @@ export function createKeyBinder(target: Window = window) {
   };
 
   const down = (e: KeyboardEvent) => {
+    console.log(`[INPUT] keydown code=${e.code}`);
+    if (e.code.startsWith("Arrow") || e.code === "Space") {
+      e.preventDefault();
+    }
     switch (e.code) {
       case "KeyA":
       case "ArrowLeft":
@@ -91,6 +95,9 @@ export function createKeyBinder(target: Window = window) {
   };
 
   const up = (e: KeyboardEvent) => {
+    if (e.code.startsWith("Arrow") || e.code === "Space") {
+      e.preventDefault();
+    }
     switch (e.code) {
       case "KeyA":
       case "ArrowLeft":
@@ -119,8 +126,8 @@ export function createKeyBinder(target: Window = window) {
     }
   };
 
-  target.addEventListener("keydown", down);
-  target.addEventListener("keyup", up);
+  target.addEventListener("keydown", down, { passive: false });
+  target.addEventListener("keyup", up, { passive: false });
 
   const dispose = () => {
     target.removeEventListener("keydown", down);

--- a/src/game/net/matchChannel.ts
+++ b/src/game/net/matchChannel.ts
@@ -1,3 +1,4 @@
+import { publishInput } from "../../net/ActionBus";
 import { createArenaPeerService, type ArenaPeerService, type ArenaStateSnapshot } from "./arenaSync";
 
 export type AuthoritativeSnapshot = ArenaStateSnapshot;
@@ -32,8 +33,14 @@ export function createMatchChannel(options: CreateMatchChannelOptions): MatchCha
   };
 
   return {
-    publishInputs() {
-      // Networking bridge not yet implemented; clients rely on peer snapshots only.
+    publishInputs(payload) {
+      publishInput({
+        left: !!payload.left,
+        right: !!payload.right,
+        jump: !!payload.jump || !!payload.up,
+        attack: !!payload.attack || !!payload.attack1 || !!payload.attack2,
+        codename: typeof payload.codename === "string" ? payload.codename : undefined,
+      });
     },
     onSnapshot(cb) {
       snapshotListeners.add(cb);

--- a/src/sim/reducer.ts
+++ b/src/sim/reducer.ts
@@ -390,7 +390,9 @@ export function applyActions(sim: Sim, actions: ActionDoc[], dtMs: number): void
 
   for (const action of relevantActions) {
     const previous = internal._inputs[action.playerId] ?? {};
-    internal._inputs[action.playerId] = { ...previous, ...action.input };
+    const merged = { ...previous, ...action.input };
+    internal._inputs[action.playerId] = merged;
+    console.log(`[SIM] move applied player=${action.playerId}`, merged);
     const current = internal._lastAppliedSeq[action.playerId] ?? 0;
     if (action.seq > current) {
       internal._lastAppliedSeq[action.playerId] = action.seq;


### PR DESCRIPTION
## Summary
- initialize and tear down the network action bus when the arena runtime boots
- attach the shared keyboard binder to window and publish inputs through the match channel
- add debugging logs while feeding host simulation input actions

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d043c2a97c832eaa9be773dde8bf94