### PR TITLE
Preserve joinedAt across arena heartbeats

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -5,6 +5,7 @@ import {
   db,
   ensureAnonAuth,
   joinArena,
+  heartbeatArenaPresence,
   leaveArena,
   claimArenaSeat,       // remove if not used
   releaseArenaSeat,     // remove if not used
@@ -235,9 +236,15 @@ const arenaTitle = arenaName ?? "Arena";
       return fallback;
     };
 
-    const pushPresence = async () => {
+    const pushJoin = async () => {
       const nextDisplayName = await computeDisplayName();
       await joinArena(arenaId, uid, codename, profileId, nextDisplayName);
+      console.log(`[PRESENCE] joined uid=${uid}`);
+    };
+
+    const pushHeartbeat = async () => {
+      const nextDisplayName = await computeDisplayName();
+      await heartbeatArenaPresence(arenaId, uid, codename, profileId, nextDisplayName);
       console.log(`[HEARTBEAT] lastSeen updated uid=${uid}`);
     };
 
@@ -248,14 +255,14 @@ const arenaTitle = arenaName ?? "Arena";
         if (cancelled) return;
 
         debugLog("[PRESENCE] joinArena", { arenaId, uid, codename, profileId });
-        await pushPresence();
+        await pushJoin();
         if (cancelled) return;
 
         debugLog("[PRESENCE] join complete", { arenaId, uid });
 
         heartbeat = setInterval(() => {
           debugLog("[PRESENCE] heartbeat", { arenaId, uid });
-          pushPresence().catch((e) => {
+          pushHeartbeat().catch((e) => {
             debugWarn("[PRESENCE] heartbeat failed", e);
           });
         }, 10_000);

--- a/src/utils/useArenaRuntime.ts
+++ b/src/utils/useArenaRuntime.ts
@@ -45,6 +45,7 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
   const hostLoopRef = useRef<HostLoopController | null>(null);
   const hostContextRef = useRef<string | null>(null);
   const keyBinderRef = useRef<ReturnType<typeof createKeyBinder> | null>(null);
+  const hostLogRef = useRef<string | null>(null);
   const [gameBooted, setGameBooted] = useState(false);
 
   const teardown = useCallback(() => {
@@ -153,6 +154,25 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
   const hostAuthUid = hostEntry?.authUid ?? null;
   const hostPlayerId = hostEntry?.playerId ?? null;
   const isHost = Boolean(meUid && hostAuthUid && hostAuthUid === meUid);
+
+  useEffect(() => {
+    if (!arenaId) return;
+    const joinedAt = hostEntry?.joinedAt ?? null;
+    const logKey = hostEntry ? `${hostEntry.authUid ?? "(unknown)"}|${joinedAt ?? "(missing)"}` : "none";
+    if (hostLogRef.current === logKey) {
+      return;
+    }
+    hostLogRef.current = logKey;
+    if (DEBUG) {
+      if (!hostEntry) {
+        console.info(`[HOST] no active host for arena=${arenaId}`);
+      } else {
+        console.info(
+          `[HOST] elected authUid=${hostEntry.authUid ?? "(unknown)"} playerId=${hostEntry.playerId ?? "(unknown)"} joinedAt=${joinedAt ?? "(missing)"} lastSeen=${hostEntry.lastSeen ?? "(missing)"}`,
+        );
+      }
+    }
+  }, [arenaId, hostEntry, hostEntry?.authUid, hostEntry?.joinedAt, hostEntry?.lastSeen, hostEntry?.playerId]);
 
   useEffect(() => {
     if (!shouldBoot) {


### PR DESCRIPTION
## Summary
- ensure arena joins only stamp joinedAt when the presence doc is first created and add a dedicated heartbeat updater that refreshes lastSeen/expireAt
- call the new heartbeat helper from ArenaPage so periodic pulses no longer reset the join timestamp
- add debug logging around host election to confirm joinedAt stability under sustained heartbeats

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d049a400e0832ebb5192f65aff9596