### PR TITLE
Allow boss profile access for authenticated users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -46,6 +46,11 @@ service cloud.firestore {
       allow read, write: if isSignedIn();
     }
 
+    // Boss (new)
+    match /boss/{doc} {
+      allow read, write: if isSignedIn();
+    }
+
     // Leaderboard (existing)
     match /leaderboard/{entry} {
       allow read: if isSignedIn();


### PR DESCRIPTION
## Summary
- grant authenticated users read and write access to the boss collection in Firestore rules

## Testing
- not run (firebase CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d049abe118832e8f718e1e0133510c