### PR TITLE
Remove duplicate presence roster import

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -30,7 +30,6 @@ import {
   primePresenceDisplayNameCache,
   usePresenceRoster,
 } from "../utils/useArenaPresence";
-import { usePresenceRoster, formatRosterNames } from "../utils/usePresenceRoster";
 
 import { useAuth } from "../context/AuthContext";
 import TouchControls from "../game/input/TouchControls";
@@ -104,9 +103,9 @@ const formattedRosterNames = useMemo(() => {
     if (!arenaId) return;
     if (presenceLoading) return;
     console.log(
-      `[ARENA] roster arena=${arenaId} n=${roster.length} names=${formattedRosterNames}`,
+      `[ARENA] roster arena=${arenaId} n=${presence.length} names=${formattedRosterNames}`,
     );
-  }, [arenaId, formattedRosterNames, presenceLoading, roster]);
+  }, [arenaId, formattedRosterNames, presence.length, presenceLoading]);
 
   useEffect(() => {
     if (typeof window === "undefined") {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,7 +22,7 @@ const formattedRoster = useMemo(() => {
   return rosterCount > 3 ? `${head} (+${rosterCount - 3})` : head;
 }, [rosterNames, rosterCount]);
 
-const occupancy = rosterCount;
+const overflow = Math.max(0, rosterCount - rosterNames.length);
 
 React.useEffect(() => {
   if (presenceLoading) return;


### PR DESCRIPTION
## Summary
- remove the duplicate usePresenceRoster import from the arena page and rely on the canonical hook
- adjust arena roster logging to reference the live presence list returned by useArenaPresence
- ensure the lobby roster chip computes its overflow indicator before rendering

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d05567cf50832e9dcbce5a4c99416b