### PR TITLE
Fix roster logging and resolve undefined identifiers

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -28,9 +28,8 @@ import {
   useArenaPresence,
   usePresenceDisplayNameResolver,
   primePresenceDisplayNameCache,
-  usePresenceRoster,
 } from "../utils/useArenaPresence";
-import { usePresenceRoster, formatRosterNames } from "../utils/usePresenceRoster";
+import { usePresenceRoster } from "../utils/usePresenceRoster";
 
 import { useAuth } from "../context/AuthContext";
 import TouchControls from "../game/input/TouchControls";
@@ -58,19 +57,24 @@ export default function ArenaPage() {
   const [runtimeMessage, setRuntimeMessage] = useState<string | null>(null);
 
 
-const {
-  players: presence,
-  loading: presenceLoading,
-  error: presenceError,
-} = useArenaPresence(arenaId);
+  const {
+    players: presence,
+    loading: presenceLoading,
+    error: presenceError,
+  } = useArenaPresence(arenaId);
 
-const { names: rosterNames, count: rosterCount } = usePresenceRoster(arenaId);
+  const rosterEntries = usePresenceRoster(presence);
+  const rosterNames = useMemo(
+    () => rosterEntries.map((entry) => entry.name),
+    [rosterEntries],
+  );
+  const rosterCount = rosterEntries.length;
 
-// Optional: formatted chip string for UI
-const formattedRosterNames = useMemo(() => {
-  const head = rosterNames.slice(0, 3).join(", ");
-  return rosterCount > 3 ? `${head} (+${rosterCount - 3})` : head;
-}, [rosterNames, rosterCount]);
+  // Optional: formatted chip string for UI
+  const formattedRosterNames = useMemo(() => {
+    const head = rosterNames.slice(0, 3).join(", ");
+    return rosterCount > 3 ? `${head} (+${rosterCount - 3})` : head;
+  }, [rosterNames, rosterCount]);
 
   const { user, player, authReady } = useAuth();
 
@@ -103,10 +107,11 @@ const formattedRosterNames = useMemo(() => {
   useEffect(() => {
     if (!arenaId) return;
     if (presenceLoading) return;
-    console.log(
-      `[ARENA] roster arena=${arenaId} n=${roster.length} names=${formattedRosterNames}`,
+    debugLog(
+      `[ARENA] roster arena=${arenaId} n=${rosterCount} names=${formattedRosterNames}`,
+      { rosterNames },
     );
-  }, [arenaId, formattedRosterNames, presenceLoading, roster]);
+  }, [arenaId, formattedRosterNames, presenceLoading, rosterCount, rosterNames]);
 
   useEffect(() => {
     if (typeof window === "undefined") {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,6 +16,8 @@ const ArenaListItem = ({ arena, onJoin }: ArenaListItemProps) => {
 const { loading: presenceLoading } = useArenaPresence(arena.id);
 const { names: rosterNames, count: rosterCount } = usePresenceRoster(arena.id);
 
+const overflow = Math.max(rosterCount - rosterNames.length, 0);
+
 // "Ben, Zane, Asha (+2)" style chip
 const formattedRoster = useMemo(() => {
   const head = rosterNames.slice(0, 3).join(", ");


### PR DESCRIPTION
## Summary
- map arena presence entries to roster names/count before logging updates
- replace direct console logging of roster changes with debug logging including roster metadata
- compute lobby roster overflow count to avoid undefined identifier errors

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68d0556b97cc832ea9c939dc0c335d76