### PR TITLE
Fix overflow calculation in HomePage roster chips

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ const ArenaListItem = ({ arena, onJoin }: ArenaListItemProps) => {
 // seatless roster (Lobby card)
 const { loading: presenceLoading } = useArenaPresence(arena.id);
 const { names: rosterNames, count: rosterCount } = usePresenceRoster(arena.id);
+const overflow = Math.max(0, rosterCount - rosterNames.length);
 
 // "Ben, Zane, Asha (+2)" style chip
 const formattedRoster = useMemo(() => {
@@ -48,7 +49,12 @@ React.useEffect(() => {
       {presenceLoading ? (
         <span className="skel" style={{ width: 160, height: 16, display: "block", marginTop: 8 }} />
       ) : rosterNames.length ? (
-        <div className="chips" style={{ marginTop: 8 }}>
+        <div
+          className="chips"
+          style={{ marginTop: 8 }}
+          aria-label={formattedRoster || undefined}
+          title={formattedRoster || undefined}
+        >
           {rosterNames.map((name, index) => (
             <span className="chip" key={`${name}-${index}`}>
               {name}


### PR DESCRIPTION
## Summary
- define an overflow count for lobby roster chips to prevent undefined access
- expose the formatted roster memo through chip container metadata while keeping the overflow chip

## Testing
- `npx tsc --noEmit` *(fails: existing duplicate identifier and missing symbol errors in src/pages/ArenaPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d0556e5e30832e8d559297c4ad15d8