### PR TITLE
Fix roster logging effects

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -108,13 +108,15 @@ export default function ArenaPage() {
   useEffect(() => {
     if (!arenaId) return;
     if (presenceLoading) return;
-useEffect(() => {
-  if (presenceLoading) return;
-  debugLog(
-    `[ARENA] roster arena=${arenaId} n=${rosterCount} names=${formattedRosterNames}`,
-    { rosterNames }
-  );
-}, [arenaId, formattedRosterNames, presenceLoading, rosterCount, rosterNames]);
+  }, [arenaId, presenceLoading]);
+
+  useEffect(() => {
+    if (presenceLoading) return;
+    debugLog(
+      `[ARENA] roster arena=${arenaId} n=${rosterCount} names=${formattedRosterNames}`,
+      { rosterNames }
+    );
+  }, [arenaId, formattedRosterNames, presenceLoading, rosterCount, rosterNames]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- restore the guard effect that watches arenaId and presenceLoading
- add a dedicated roster logging effect with the provided dependency list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0589d7504832e8eab02121657801e