### PR TITLE
Update arena roster usage

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -64,12 +64,7 @@ export default function ArenaPage() {
     error: presenceError,
   } = useArenaPresence(arenaId);
 
-  const rosterEntries = usePresenceRoster(presence);
-  const rosterNames = useMemo(
-    () => rosterEntries.map((entry) => entry.name),
-    [rosterEntries],
-  );
-  const rosterCount = rosterEntries.length;
+  const { names: rosterNames, count: rosterCount } = usePresenceRoster(arenaId);
 
   // Optional: formatted chip string for UI
   const formattedRosterNames = useMemo(() => {


### PR DESCRIPTION
## Summary
- read arena roster directly from usePresenceRoster using the arena id
- remove redundant memoization and count derivation now handled by the hook
- keep formatted roster memo and downstream consumers updated to use roster names/count

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d058a303d4832ea06dccbdd228a1e7