### PR TITLE
Deduplicate arena roster overflow handling

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,27 +12,23 @@ interface ArenaListItemProps {
 }
 
 const ArenaListItem = ({ arena, onJoin }: ArenaListItemProps) => {
-// seatless roster (Lobby card)
-const { loading: presenceLoading } = useArenaPresence(arena.id);
-const { names: rosterNames, count: rosterCount } = usePresenceRoster(arena.id);
-const overflow = Math.max(0, rosterCount - rosterNames.length);
+  // seatless roster (Lobby card)
+  const { loading: presenceLoading } = useArenaPresence(arena.id);
+  const { names: rosterNames, count: rosterCount } = usePresenceRoster(arena.id);
+  const overflow = Math.max(0, rosterCount - rosterNames.length);
 
-const overflow = Math.max(rosterCount - rosterNames.length, 0);
+  // "Ben, Zane, Asha (+2)" style chip
+  const formattedRoster = useMemo(() => {
+    const head = rosterNames.slice(0, 3).join(", ");
+    return rosterCount > 3 ? `${head} (+${rosterCount - 3})` : head;
+  }, [rosterNames, rosterCount]);
 
-// "Ben, Zane, Asha (+2)" style chip
-const formattedRoster = useMemo(() => {
-  const head = rosterNames.slice(0, 3).join(", ");
-  return rosterCount > 3 ? `${head} (+${rosterCount - 3})` : head;
-}, [rosterNames, rosterCount]);
-
-const overflow = Math.max(0, rosterCount - rosterNames.length);
-
-React.useEffect(() => {
-  if (presenceLoading) return;
-  console.log(
-    `[LOBBY] arena=${arena.id} liveCount=${rosterCount} names=${formattedRoster}`
-  );
-}, [arena.id, presenceLoading, rosterCount, formattedRoster]);
+  React.useEffect(() => {
+    if (presenceLoading) return;
+    console.log(
+      `[LOBBY] arena=${arena.id} liveCount=${rosterCount} names=${formattedRoster}`
+    );
+  }, [arena.id, presenceLoading, rosterCount, formattedRoster]);
 
   const capacityLabel = useMemo(() => {
     if (presenceLoading) return null;


### PR DESCRIPTION
## Summary
- deduplicate the arena roster overflow calculation within `ArenaListItem`
- keep a single memoized roster formatter and ensure the lobby log effect depends on it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d058a956c8832ebe9b27f17e4d0805