### PR TITLE
Remove unused seat helpers from ArenaPage imports

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -4,12 +4,9 @@ import { useParams, useNavigate } from "react-router-dom";
 import {
   db,
   ensureAnonAuth,
-  joinArena,
   heartbeatArenaPresence,
+  joinArena,
   leaveArena,
-  claimArenaSeat,       // remove if not used
-  releaseArenaSeat,     // remove if not used
-  initArenaPlayerState, // remove if not used
   watchLeaderboard,
 } from "../firebase";
 import type { LeaderboardEntry } from "../firebase";


### PR DESCRIPTION
## Summary
- remove unused arena seat helper imports from ArenaPage
- keep firebase import list alphabetized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d058ad905c832e8e570627d3363c81