### PR TITLE
Refactor arena runtime writer election and host loop

### DIFF
--- a/src/lib/arenaState.ts
+++ b/src/lib/arenaState.ts
@@ -13,8 +13,9 @@ import { ensureAnonAuth } from "../firebase";
 
 export type ArenaState = {
   tick: number;
+  writerUid?: string | null;
   lastUpdate?: unknown; // Firestore Timestamp
-  players: Record<string, { hp: number; updatedAt?: unknown }>;
+  entities?: Record<string, { hp?: number; updatedAt?: unknown; x?: number; y?: number }>;
 };
 
 export const arenaStateRef = (db: Firestore, arenaId: string): DocumentReference =>
@@ -32,7 +33,7 @@ export async function ensureArenaState(
     console.info("[ARENA] ensureArenaState: creating doc", { arenaId });
     await setDoc(
       ref,
-      { tick: 0, players: {}, lastUpdate: serverTimestamp() } as ArenaState,
+      { tick: 0, writerUid: null, entities: {}, lastUpdate: serverTimestamp() } as ArenaState,
       { merge: true }
     );
   }
@@ -80,9 +81,6 @@ export async function touchPlayer(
     ref,
     {
       lastUpdate: serverTimestamp(),
-      players: {
-        [user.uid]: { hp: initHp, updatedAt: serverTimestamp() },
-      },
     },
     { merge: true }
   );

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -336,26 +336,16 @@ export default function ArenaPage() {
 
   const meUid = user?.uid ?? null;
 
-  const hostEntry = useMemo(() => {
-    if (!presence.length) return null;
-    const parseTs = (value?: string) => {
-      if (!value) return Number.POSITIVE_INFINITY;
-      const parsed = Date.parse(value);
-      return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
-    };
-    return [...presence].sort((a, b) => {
-      const aTs = parseTs(a.joinedAt);
-      const bTs = parseTs(b.joinedAt);
-      if (aTs !== bTs) return aTs - bTs;
-      const aKey = a.playerId ?? a.authUid ?? "";
-      const bKey = b.playerId ?? b.authUid ?? "";
-      return aKey.localeCompare(bKey);
-    })[0];
-  }, [presence]);
+  const writerUid = state?.writerUid ?? null;
 
-  const hostLabel = hostEntry
-    ? `${hostEntry.codename ?? hostEntry.playerId.slice(0, 6)}${
-        hostEntry.authUid && hostEntry.authUid === meUid ? " (you)" : ""
+  const writerEntry = useMemo(() => {
+    if (!writerUid) return null;
+    return presence.find((entry) => (entry.authUid ?? entry.playerId) === writerUid) ?? null;
+  }, [presence, writerUid]);
+
+  const hostLabel = writerEntry
+    ? `${writerEntry.codename ?? writerEntry.playerId.slice(0, 6)}${
+        writerEntry.authUid && writerEntry.authUid === meUid ? " (you)" : ""
       }`
     : "—";
 
@@ -366,6 +356,7 @@ export default function ArenaPage() {
     meUid,
     codename: player?.codename ?? null,
     presence,
+    writerUid,
     canvasRef,
     onBootError: (message) => setRuntimeMessage((prev) => prev ?? message),
   });


### PR DESCRIPTION
## Summary
- elect and persist the arena writer from active presence, logging transitions and using the value to control host duties
- replace the host loop with presence/input subscriptions that spawn/despawn fighters, step simple physics, and publish the new entity state payload
- extend Firebase helpers, arena state wiring, and UI to read/write the new writerUid and entities format

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0686dc33c832ea6e2b653aa3b315b