### PR TITLE
Refactor arena rendering for entity snapshots

### DIFF
--- a/src/game/arena/ArenaScene.ts
+++ b/src/game/arena/ArenaScene.ts
@@ -1,18 +1,23 @@
 import Phaser from "phaser";
 import { Player } from "../entities/Player";
 import { RemoteOpponent } from "../entities/RemoteOpponent";
-
-// Host-authoritative networking (no peer state writes)
 import {
   createMatchChannel,
   type MatchChannel,
   type AuthoritativeSnapshot,
 } from "../net/matchChannel";
+import type { ArenaEntityFrame, ArenaPlayerFrame } from "../net/arenaSync";
 import { SnapshotBuffer } from "../net/snapshotBuffer";
+import { debugLog } from "../../net/debug";
 
 const WORLD_WIDTH = 960;
 const WORLD_HEIGHT = 540;
 const GROUND_HEIGHT = 40;
+const RENDER_INTERPOLATION_DELAY_MS = 120;
+const LOCAL_CORRECTION_THRESHOLD = 2;
+const LOCAL_SNAP_THRESHOLD = 72;
+const LOCAL_CORRECTION_LERP = 0.35;
+const PRESENCE_DESPAWN_BUFFER_MS = 20_000;
 
 export interface ArenaSceneConfig {
   arenaId: string;
@@ -25,13 +30,39 @@ export interface ArenaSceneConfig {
   isHostClient?: boolean;
 }
 
+interface NormalizedEntityState {
+  id: string;
+  kind: string;
+  playerId?: string;
+  codename?: string;
+  x?: number;
+  y?: number;
+  vx?: number;
+  vy?: number;
+  hp?: number;
+  facing?: -1 | 1;
+  facingLabel?: "L" | "R";
+  anim?: string;
+  attackActiveUntil?: number;
+  canAttackAt?: number;
+  grounded?: boolean;
+  presenceExpireAtMs?: number;
+}
+
+interface RemoteActorState {
+  actor: RemoteOpponent;
+  hp: number;
+  codename?: string;
+  presenceExpireAtMs?: number;
+  lastSeenAt: number;
+}
+
 export default class ArenaScene extends Phaser.Scene {
   private arenaId!: string;
   private me!: { id: string; codename: string };
   private spawn!: { x: number; y: number };
 
   private player?: Player;
-  private opponent?: RemoteOpponent;
   private ground?: Phaser.GameObjects.Rectangle;
 
   private hudText?: Phaser.GameObjects.Text;
@@ -43,9 +74,8 @@ export default class ArenaScene extends Phaser.Scene {
 
   // Net & interpolation
   private channel?: MatchChannel;
-  private snapbuf = new SnapshotBuffer<AuthoritativeSnapshot>(4);
-  private latestOpponentName = "";
-  private opponentId?: string;
+  private snapbuf = new SnapshotBuffer<AuthoritativeSnapshot>(6);
+  private remoteActors = new Map<string, RemoteActorState>();
 
   // role/seat (optional UI later)
   private isHost = false;
@@ -67,11 +97,9 @@ export default class ArenaScene extends Phaser.Scene {
 
     this.createGround();
 
-    // Local player and remote opponent visuals
+    // Local player visuals + physics
     this.player = new Player(this, this.spawn.x, this.spawn.y);
     this.player.healFull();
-
-    this.opponent = new RemoteOpponent(this, this.spawn.x, this.spawn.y);
 
     if (this.ground && this.player) {
       this.physics.add.collider(this.player.sprite, this.ground);
@@ -85,7 +113,9 @@ export default class ArenaScene extends Phaser.Scene {
     this.textureAddHandler = () => {
       this.tryPromoteFighterRigs();
       this.player?.handleTextureUpdate();
-      this.opponent?.handleTextureUpdate();
+      for (const remote of this.remoteActors.values()) {
+        remote.actor.handleTextureUpdate();
+      }
     };
     this.textures.on(Phaser.Textures.Events.ADD, this.textureAddHandler, this);
 
@@ -107,11 +137,6 @@ export default class ArenaScene extends Phaser.Scene {
         return;
       }
       this.snapbuf.push(snap, this.time.now);
-      // KO flash when my hp crosses >0 → <=0 (visual only; respawn is authoritative)
-      const meNode = snap.players?.[this.me.id];
-      if (meNode && this.player && this.player.hp > 0 && (meNode.hp ?? 100) <= 0) {
-        this.flashKo();
-      }
     });
 
     // Clean teardown
@@ -134,59 +159,401 @@ export default class ArenaScene extends Phaser.Scene {
     this.applyInterpolatedState();
   }
 
-  /** Apply interpolated authoritative snapshot to entities (no local prediction). */
   private applyInterpolatedState() {
-    const view = this.snapbuf.getInterpolated(this.time.now);
-    if (!view) return;
+    const frame = this.snapbuf.getInterpolated(this.time.now, RENDER_INTERPOLATION_DELAY_MS);
+    if (!frame) return;
 
-    const players = view.players ?? {};
+    const previousSnap = frame.previous?.snapshot;
+    const nextSnap = frame.next?.snapshot ?? previousSnap;
+    if (!nextSnap) return;
 
-    // Me (local fighter visuals mirror authoritative state)
-    const meState = players[this.me.id];
-    if (meState && this.player) {
-      const pos = meState.pos;
-      const x = typeof pos?.x === "number" ? pos.x : this.spawn.x;
-      const y = typeof pos?.y === "number" ? pos.y : this.spawn.y;
-      this.player.setPosition(x, y);
-      this.player.setFacing(meState.dir === -1 ? "L" : "R");
-      if (typeof meState.hp === "number") this.player.setHp(meState.hp);
-      if (typeof meState.attackActiveUntil === "number" && meState.attackActiveUntil > this.time.now) {
-        this.player.playAnim("attack");
+    const writerUid = nextSnap.writerUid ?? previousSnap?.writerUid ?? null;
+    const snapshotTimeMs =
+      typeof nextSnap.tMs === "number"
+        ? nextSnap.tMs
+        : typeof previousSnap?.tMs === "number"
+        ? previousSnap.tMs
+        : Date.now();
+
+    const ids = new Set<string>();
+    this.collectEntityIds(previousSnap, ids);
+    this.collectEntityIds(nextSnap, ids);
+
+    if (ids.size === 0) {
+      this.collectPlayerIds(previousSnap, ids);
+      this.collectPlayerIds(nextSnap, ids);
+    }
+
+    const seen = new Set<string>();
+
+    for (const id of ids) {
+      const prevNode = this.getEntityData(previousSnap, id);
+      const nextNode = this.getEntityData(nextSnap, id);
+      const prevState = this.normalizeEntity(id, prevNode);
+      const nextState = this.normalizeEntity(id, nextNode);
+      const state = this.interpolateEntity(prevState, nextState, frame.alpha);
+      if (!state || state.kind !== "fighter") {
+        continue;
+      }
+
+      if (id !== this.me.id && this.isEntityExpired(state)) {
+        this.destroyRemoteActor(id);
+        continue;
+      }
+
+      if (id === this.me.id) {
+        seen.add(id);
+        this.updateLocalFighter(state, writerUid, snapshotTimeMs);
       } else {
-        this.player.playAnim("idle");
+        this.updateRemoteFighter(id, state, snapshotTimeMs);
+        seen.add(id);
       }
     }
 
-    // Pick first other player as opponent (temporary until seats UI wires in)
-    const otherId = Object.keys(players).find((id) => id !== this.me.id);
-    if (!otherId) {
-      this.opponentId = undefined;
-      this.opponent?.setActive(false);
-      this.latestOpponentName = "";
-      this.updateHud();
+    this.cleanupRemoteActors(seen);
+    this.updateHud();
+
+    const localCount = seen.has(this.me.id) ? 1 : 0;
+    const remoteCount = Math.max(0, seen.size - localCount);
+    debugLog(`[RENDER] entities=${seen.size} (local=${localCount}, remote=${remoteCount})`);
+  }
+
+  private collectEntityIds(snapshot: AuthoritativeSnapshot | undefined, into: Set<string>) {
+    if (!snapshot?.entities) {
       return;
     }
+    for (const [id, node] of Object.entries(snapshot.entities)) {
+      if (this.shouldRenderEntity(node)) {
+        into.add(id);
+      }
+    }
+  }
 
-    const opp = players[otherId]!;
-    this.opponentId = otherId;
-    this.opponent?.setActive(true);
-    this.opponent?.setCodename(opp.codename ?? "Agent");
-    this.opponent?.setState({
-      x: typeof opp.pos?.x === "number" ? opp.pos.x : this.spawn.x,
-      y: typeof opp.pos?.y === "number" ? opp.pos.y : this.spawn.y,
-      facing: opp.dir === -1 ? "L" : "R",
-      hp: typeof opp.hp === "number" ? opp.hp : (this.opponent?.hp ?? 100),
-      anim: typeof opp.attackActiveUntil === "number" && opp.attackActiveUntil > this.time.now ? "attack" : undefined,
-      vx: opp.vel?.x,
-      vy: opp.vel?.y,
-    });
+  private collectPlayerIds(snapshot: AuthoritativeSnapshot | undefined, into: Set<string>) {
+    if (!snapshot?.players) {
+      return;
+    }
+    for (const id of Object.keys(snapshot.players)) {
+      into.add(id);
+    }
+  }
 
-    if (this.opponent && typeof opp.hp === "number" && this.opponent.hp > 0 && opp.hp <= 0) {
-      this.flashKo();
+  private shouldRenderEntity(node: ArenaEntityFrame | undefined): boolean {
+    if (!node) return false;
+    const kind = typeof node.kind === "string" ? node.kind : undefined;
+    return !kind || kind === "fighter";
+  }
+
+  private getEntityData(
+    snapshot: AuthoritativeSnapshot | undefined,
+    id: string,
+  ): ArenaEntityFrame | ArenaPlayerFrame | undefined {
+    if (!snapshot) return undefined;
+    const entity = snapshot.entities?.[id];
+    if (entity && this.shouldRenderEntity(entity)) {
+      return entity;
+    }
+    const player = snapshot.players?.[id];
+    if (player) {
+      return player;
+    }
+    return undefined;
+  }
+
+  private normalizeEntity(
+    id: string,
+    node: ArenaEntityFrame | ArenaPlayerFrame | undefined,
+  ): NormalizedEntityState | undefined {
+    if (!node) {
+      return undefined;
+    }
+    const record = node as Record<string, unknown>;
+    const kindValue = typeof record.kind === "string" ? record.kind : "fighter";
+    if (kindValue !== "fighter") {
+      return { id, kind: kindValue };
+    }
+    const pos = record.pos as { x?: unknown; y?: unknown } | undefined;
+    const vel = record.vel as { x?: unknown; y?: unknown } | undefined;
+    const dir = record.dir;
+    const facing = record.facing;
+
+    const x = this.pickNumber(record.x, pos?.x);
+    const y = this.pickNumber(record.y, pos?.y);
+    const vx = this.pickNumber(record.vx, vel?.x);
+    const vy = this.pickNumber(record.vy, vel?.y);
+    const hp = this.pickNumber(record.hp);
+
+    const facingLabel =
+      typeof facing === "string"
+        ? facing === "L"
+          ? "L"
+          : facing === "R"
+          ? "R"
+          : undefined
+        : this.toFacingLabel(typeof dir === "number" ? dir : undefined);
+    const numericFacing =
+      typeof dir === "number"
+        ? dir < 0
+          ? -1
+          : 1
+        : facingLabel === "L"
+        ? -1
+        : facingLabel === "R"
+        ? 1
+        : undefined;
+
+    const attackActiveUntil = this.pickNumber(record.attackActiveUntil);
+    const presenceExpireAt = this.parseTime(
+      record.presenceExpireAt ?? (record.presence as { expireAt?: unknown } | undefined)?.expireAt,
+    );
+
+    return {
+      id,
+      kind: "fighter",
+      playerId: typeof record.playerId === "string" ? record.playerId : undefined,
+      codename: typeof record.codename === "string" ? record.codename : undefined,
+      x,
+      y,
+      vx,
+      vy,
+      hp,
+      facing: numericFacing,
+      facingLabel,
+      anim: typeof record.anim === "string" ? record.anim : undefined,
+      attackActiveUntil,
+      canAttackAt: this.pickNumber(record.canAttackAt),
+      grounded: typeof record.grounded === "boolean" ? record.grounded : undefined,
+      presenceExpireAtMs: presenceExpireAt,
+    };
+  }
+
+  private interpolateEntity(
+    prev: NormalizedEntityState | undefined,
+    next: NormalizedEntityState | undefined,
+    alpha: number,
+  ): NormalizedEntityState | undefined {
+    if (!prev && !next) {
+      return undefined;
+    }
+    if (!prev) {
+      return next;
+    }
+    if (!next) {
+      return prev;
     }
 
-    this.latestOpponentName = opp.codename ?? "Agent";
-    this.updateHud();
+    return {
+      id: next.id ?? prev.id,
+      kind: next.kind ?? prev.kind,
+      playerId: next.playerId ?? prev.playerId,
+      codename: next.codename ?? prev.codename,
+      x: this.lerpNumber(prev.x, next.x, alpha),
+      y: this.lerpNumber(prev.y, next.y, alpha),
+      vx: this.lerpNumber(prev.vx, next.vx, alpha),
+      vy: this.lerpNumber(prev.vy, next.vy, alpha),
+      hp: typeof next.hp === "number" ? next.hp : prev.hp,
+      facing: typeof next.facing === "number" ? next.facing : prev.facing,
+      facingLabel: next.facingLabel ?? prev.facingLabel ?? this.toFacingLabel(next.facing ?? prev.facing),
+      anim: next.anim ?? prev.anim,
+      attackActiveUntil:
+        typeof next.attackActiveUntil === "number" ? next.attackActiveUntil : prev.attackActiveUntil,
+      canAttackAt: typeof next.canAttackAt === "number" ? next.canAttackAt : prev.canAttackAt,
+      grounded: typeof next.grounded === "boolean" ? next.grounded : prev.grounded,
+      presenceExpireAtMs:
+        typeof next.presenceExpireAtMs === "number" ? next.presenceExpireAtMs : prev.presenceExpireAtMs,
+    };
+  }
+
+  private updateLocalFighter(state: NormalizedEntityState, writerUid: string | null, timeMs: number) {
+    const player = this.player;
+    if (!player) return;
+
+    const prevHp = player.hp;
+    if (typeof state.hp === "number") {
+      player.setHp(state.hp);
+      if (prevHp > 0 && state.hp <= 0) {
+        this.flashKo();
+      }
+    }
+
+    const facing = state.facingLabel ?? this.toFacingLabel(state.facing);
+    if (facing) {
+      player.setFacing(facing);
+    }
+
+    const anim = this.resolveAnim(state, timeMs);
+    if (anim === "attack") {
+      player.playAnim("attack");
+    } else if (!player.isAttackActive()) {
+      player.playAnim("idle");
+    }
+
+    if (typeof state.x === "number" && typeof state.y === "number") {
+      if (!writerUid || writerUid === this.me.id) {
+        player.setPosition(state.x, state.y);
+        if (typeof state.vx === "number" || typeof state.vy === "number") {
+          const vx = typeof state.vx === "number" ? state.vx : player.body.velocity.x;
+          const vy = typeof state.vy === "number" ? state.vy : player.body.velocity.y;
+          player.body.setVelocity(vx, vy);
+        }
+      } else {
+        const currentX = player.sprite.x;
+        const currentY = player.sprite.y;
+        const distance = Phaser.Math.Distance.Between(currentX, currentY, state.x, state.y);
+        if (distance > LOCAL_CORRECTION_THRESHOLD) {
+          const ratio = distance > LOCAL_SNAP_THRESHOLD ? 1 : LOCAL_CORRECTION_LERP;
+          player.correctState({ x: state.x, y: state.y, vx: state.vx, vy: state.vy }, ratio);
+        }
+      }
+    }
+  }
+
+  private updateRemoteFighter(id: string, state: NormalizedEntityState, timeMs: number) {
+    const meta = this.ensureRemoteActor(id);
+    const actor = meta.actor;
+
+    if (state.codename) {
+      meta.codename = state.codename;
+      actor.setCodename(state.codename);
+    }
+
+    const anim = this.resolveAnim(state, timeMs);
+    actor.setActive(true);
+    actor.setState({
+      x: typeof state.x === "number" ? state.x : actor.sprite.x,
+      y: typeof state.y === "number" ? state.y : actor.sprite.y,
+      facing: state.facingLabel ?? this.toFacingLabel(state.facing) ?? "R",
+      hp: typeof state.hp === "number" ? state.hp : undefined,
+      anim,
+      vx: state.vx,
+      vy: state.vy,
+    });
+
+    if (typeof state.hp === "number") {
+      const prevHp = meta.hp;
+      meta.hp = state.hp;
+      if (prevHp > 0 && state.hp <= 0) {
+        this.flashKo();
+      }
+    }
+
+    meta.presenceExpireAtMs = typeof state.presenceExpireAtMs === "number" ? state.presenceExpireAtMs : undefined;
+    meta.lastSeenAt = this.time.now;
+  }
+
+  private resolveAnim(state: NormalizedEntityState, timeMs: number): string | undefined {
+    if (state.anim) {
+      return state.anim;
+    }
+    if (typeof state.attackActiveUntil === "number" && timeMs < state.attackActiveUntil) {
+      return "attack";
+    }
+    return undefined;
+  }
+
+  private cleanupRemoteActors(seen: Set<string>) {
+    for (const id of [...this.remoteActors.keys()]) {
+      if (!seen.has(id)) {
+        this.destroyRemoteActor(id);
+      }
+    }
+  }
+
+  private destroyRemoteActor(id: string) {
+    const meta = this.remoteActors.get(id);
+    if (!meta) return;
+    meta.actor.destroy();
+    this.remoteActors.delete(id);
+  }
+
+  private ensureRemoteActor(id: string): RemoteActorState {
+    let meta = this.remoteActors.get(id);
+    if (!meta) {
+      const actor = new RemoteOpponent(this, this.spawn.x, this.spawn.y);
+      meta = {
+        actor,
+        hp: actor.hp,
+        codename: actor.codename,
+        lastSeenAt: this.time.now,
+      };
+      this.remoteActors.set(id, meta);
+    }
+    return meta;
+  }
+
+  private pickNumber(...values: (unknown | undefined)[]): number | undefined {
+    for (const value of values) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  private lerpNumber(a: number | undefined, b: number | undefined, alpha: number): number | undefined {
+    if (typeof a === "number" && typeof b === "number") {
+      return Phaser.Math.Linear(a, b, Phaser.Math.Clamp(alpha, 0, 1));
+    }
+    if (typeof b === "number") {
+      return b;
+    }
+    if (typeof a === "number") {
+      return a;
+    }
+    return undefined;
+  }
+
+  private toFacingLabel(dir: number | undefined): "L" | "R" | undefined {
+    if (typeof dir === "number") {
+      return dir < 0 ? "L" : "R";
+    }
+    return undefined;
+  }
+
+  private parseTime(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const ms = Date.parse(value);
+      return Number.isFinite(ms) ? ms : undefined;
+    }
+    if (value && typeof value === "object") {
+      const record = value as {
+        toMillis?: () => number;
+        toDate?: () => Date;
+        seconds?: number;
+        nanoseconds?: number;
+      };
+      if (typeof record.toMillis === "function") {
+        const ms = record.toMillis();
+        if (Number.isFinite(ms)) {
+          return ms;
+        }
+      }
+      if (typeof record.toDate === "function") {
+        const date = record.toDate();
+        if (date) {
+          const ms = date.getTime();
+          if (Number.isFinite(ms)) {
+            return ms;
+          }
+        }
+      }
+      if (typeof record.seconds === "number") {
+        const seconds = record.seconds;
+        const nanos = typeof record.nanoseconds === "number" ? record.nanoseconds : 0;
+        return seconds * 1000 + nanos / 1_000_000;
+      }
+    }
+    return undefined;
+  }
+
+  private isEntityExpired(state: NormalizedEntityState): boolean {
+    if (typeof state.presenceExpireAtMs !== "number") {
+      return false;
+    }
+    return Date.now() - state.presenceExpireAtMs > PRESENCE_DESPAWN_BUFFER_MS;
   }
 
   private createGround() {
@@ -196,7 +563,7 @@ export default class ArenaScene extends Phaser.Scene {
       groundY,
       WORLD_WIDTH,
       GROUND_HEIGHT,
-      0x1f2937
+      0x1f2937,
     );
     this.physics.add.existing(this.ground, true);
     const body = this.ground.body as Phaser.Physics.Arcade.StaticBody;
@@ -224,18 +591,25 @@ export default class ArenaScene extends Phaser.Scene {
   private updateHud() {
     if (!this.hudText) return;
     const myHp = this.player ? Math.round(this.player.hp) : 0;
-    const opponentHp =
-      this.opponent && this.opponent.sprite.visible ? Math.round(this.opponent.hp) : null;
-
     this.hudText.setText(`You (${this.me.codename}) HP: ${myHp}`);
-    if (this.oppHudText) {
-      if (opponentHp === null) {
-        this.oppHudText.setText("Waiting for opponent...");
-      } else {
-        const name = this.latestOpponentName || "Opponent";
-        this.oppHudText.setText(`${name} HP: ${opponentHp}`);
-      }
+    if (!this.oppHudText) {
+      return;
     }
+    if (this.remoteActors.size === 0) {
+      this.oppHudText.setText("Waiting for opponent...");
+      return;
+    }
+
+    const entries = [...this.remoteActors.entries()];
+    entries.sort((a, b) => {
+      const bySeen = b[1].lastSeenAt - a[1].lastSeenAt;
+      if (bySeen !== 0) return bySeen;
+      return a[0].localeCompare(b[0]);
+    });
+    const [, primary] = entries[0]!;
+    const name = primary.codename ?? primary.actor.codename ?? "Opponent";
+    const hp = Math.round(primary.actor.hp);
+    this.oppHudText.setText(`${name} HP: ${hp}`);
   }
 
   private createKoText() {
@@ -276,8 +650,10 @@ export default class ArenaScene extends Phaser.Scene {
     this.player?.destroy();
     this.player = undefined;
 
-    this.opponent?.destroy();
-    this.opponent = undefined;
+    for (const remote of this.remoteActors.values()) {
+      remote.actor.destroy();
+    }
+    this.remoteActors.clear();
 
     this.hudText?.destroy();
     this.hudText = undefined;
@@ -299,6 +675,8 @@ export default class ArenaScene extends Phaser.Scene {
 
   private tryPromoteFighterRigs() {
     this.player?.refreshRig();
-    this.opponent?.refreshRig();
+    for (const remote of this.remoteActors.values()) {
+      remote.actor.refreshRig();
+    }
   }
 }

--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -217,6 +217,22 @@ export class Player extends Phaser.Events.EventEmitter {
     this.updateRigVisual();
   }
 
+  correctState(target: { x: number; y: number; vx?: number; vy?: number }, ratio: number) {
+    const t = Phaser.Math.Clamp(ratio, 0, 1);
+    const x = Phaser.Math.Linear(this.sprite.x, target.x, t);
+    const y = Phaser.Math.Linear(this.sprite.y, target.y, t);
+    const vx =
+      typeof target.vx === "number"
+        ? Phaser.Math.Linear(this.body.velocity.x, target.vx, t)
+        : this.body.velocity.x;
+    const vy =
+      typeof target.vy === "number"
+        ? Phaser.Math.Linear(this.body.velocity.y, target.vy, t)
+        : this.body.velocity.y;
+    this.setPosition(x, y);
+    this.body.setVelocity(vx, vy);
+  }
+
   setFacing(direction: "L" | "R") {
     const next = direction === "L" ? -1 : 1;
     if (this.facing === next) {

--- a/src/game/net/arenaSync.ts
+++ b/src/game/net/arenaSync.ts
@@ -25,9 +25,34 @@ export type ArenaPlayerFrame = {
   grounded?: boolean;
 };
 
+export type ArenaEntityFrame = {
+  kind?: string;
+  playerId?: string;
+  codename?: string;
+  pos?: { x?: number; y?: number };
+  vel?: { x?: number; y?: number };
+  dir?: -1 | 1;
+  facing?: "L" | "R";
+  x?: number;
+  y?: number;
+  vx?: number;
+  vy?: number;
+  hp?: number;
+  anim?: string;
+  attackActiveUntil?: number;
+  canAttackAt?: number;
+  grounded?: boolean;
+  presenceExpireAt?: unknown;
+  presence?: { expireAt?: unknown };
+  updatedAt?: unknown;
+};
+
 export type ArenaStateSnapshot = {
   tick?: number;
+  tMs?: number;
+  writerUid?: string;
   phase?: ArenaPhase;
+  entities?: Record<string, ArenaEntityFrame | undefined>;
   players?: Record<string, ArenaPlayerFrame | undefined>;
   lastEvent?: ArenaLastEvent;
 };

--- a/src/game/net/snapshotBuffer.ts
+++ b/src/game/net/snapshotBuffer.ts
@@ -1,3 +1,5 @@
+import Phaser from "phaser";
+
 export type SnapshotEntry<T> = {
   snapshot: T;
   timestamp: number;
@@ -16,11 +18,45 @@ export class SnapshotBuffer<T> {
     }
   }
 
-  getInterpolated(_now: number): T | undefined {
+  getInterpolated(
+    now: number,
+    delayMs = 100,
+  ): { previous?: SnapshotEntry<T>; next?: SnapshotEntry<T>; alpha: number; renderTimestamp: number } | undefined {
     if (this.entries.length === 0) {
       return undefined;
     }
-    return this.entries[this.entries.length - 1]!.snapshot;
+
+    const renderTimestamp = now - delayMs;
+    const entries = this.entries;
+
+    let previous: SnapshotEntry<T> | undefined;
+    let next: SnapshotEntry<T> | undefined;
+
+    for (let i = 0; i < entries.length; i += 1) {
+      const entry = entries[i]!;
+      if (entry.timestamp <= renderTimestamp) {
+        previous = entry;
+        continue;
+      }
+      next = entry;
+      break;
+    }
+
+    if (!previous) {
+      previous = entries[0];
+    }
+    if (!next) {
+      next = entries[entries.length - 1];
+    }
+
+    if (!previous || !next) {
+      return undefined;
+    }
+
+    const span = next.timestamp - previous.timestamp;
+    const alpha = span > 0 ? Phaser.Math.Clamp((renderTimestamp - previous.timestamp) / span, 0, 1) : 0;
+
+    return { previous, next, alpha, renderTimestamp };
   }
 
   clear(): void {


### PR DESCRIPTION
## Summary
- render arena fighters from `snapshot.entities`, instantiating and removing remote opponents per entity id while logging the counts and respecting presence expiry windows
- add lightweight local prediction and reconciliation for the player when snapshots come from a remote writer, and interpolate remote fighters via the snapshot buffer
- extend the snapshot buffer interpolation utility, player entity controls, and arena snapshot typing to support the new entity stream

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0687659c4832eab140d29bfa98d65