### PR TITLE
Restrict arena state current writes to matching writer

### DIFF
--- a/emulator/README.md
+++ b/emulator/README.md
@@ -1,0 +1,33 @@
+# Firebase Emulator Notes
+
+## Firestore rule snippets
+
+```rules
+match /arenas/{arenaId}/state/{stateId} {
+  function hasMatchingWriterUid() {
+    return (request.resource != null && request.resource.data.writerUid == request.auth.uid)
+      || (resource != null && resource.data.writerUid == request.auth.uid);
+  }
+
+  allow read: if isSignedIn();
+  allow write: if isSignedIn()
+    && (stateId != "current" || hasMatchingWriterUid());
+}
+```
+
+`state/current` can only be created, updated, or deleted by the user whose UID matches the `writerUid` field on the incoming data (or the document's stored writer). Other arena state documents remain writable by any authenticated client.
+
+```rules
+match /arenas/{arenaId} {
+  match /inputs/{uid} {
+    allow read: if isSignedIn();
+    allow write: if isSignedIn() && request.auth.uid == uid;
+  }
+
+  match /presence/{playerId} {
+    allow read, write: if isSignedIn();
+  }
+}
+```
+
+Inputs, presence, and state reads continue to work for anonymous-authenticated sessions, but each input document stays owner-writable only.

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,7 +33,14 @@ service cloud.firestore {
 
     // IMPORTANT: arena state docs live at /arenas/{arenaId}/state/{stateId}
     match /arenas/{arenaId}/state/{stateId} {
-      allow read, write: if isSignedIn();
+      function hasMatchingWriterUid() {
+        return (request.resource != null && request.resource.data.writerUid == request.auth.uid)
+          || (resource != null && resource.data.writerUid == request.auth.uid);
+      }
+
+      allow read: if isSignedIn();
+      allow write: if isSignedIn()
+        && (stateId != "current" || hasMatchingWriterUid());
     }
 
     // Players (existing)


### PR DESCRIPTION
## Summary
- require matching writerUid for writes to /arenas/{arenaId}/state/current
- document the rule update plus input/presence access in emulator README snippets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0687d6aa4832e8d423faa0da2bca7