### PR TITLE
Relax arena presence timeouts and improve writer failover

### DIFF
--- a/src/game/net/arenaSync.ts
+++ b/src/game/net/arenaSync.ts
@@ -55,7 +55,6 @@ export type ArenaStateSnapshot = {
   entities?: Record<string, ArenaEntityFrame | undefined>;
   players?: Record<string, ArenaPlayerFrame | undefined>;
   lastEvent?: ArenaLastEvent;
-  writerUid?: string;
 };
 
 export interface ArenaHostOptions {

--- a/src/utils/presenceThresholds.ts
+++ b/src/utils/presenceThresholds.ts
@@ -1,0 +1,30 @@
+import type { ArenaPresenceEntry } from "../types/models";
+
+export const HEARTBEAT_INTERVAL_MS = 10_000;
+export const HEARTBEAT_ACTIVE_WINDOW_MS = 20_000;
+export const PRESENCE_GRACE_BUFFER_MS = 60_000;
+
+const parseIsoDate = (value?: string | null): number => {
+  if (typeof value !== "string" || value.length === 0) {
+    return Number.NaN;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+};
+
+export const isPresenceEntryActive = (
+  entry: ArenaPresenceEntry,
+  now: number = Date.now(),
+): boolean => {
+  const expireAtMs = parseIsoDate(entry.expireAt ?? null);
+  if (Number.isFinite(expireAtMs) && now <= expireAtMs + PRESENCE_GRACE_BUFFER_MS) {
+    return true;
+  }
+
+  const lastSeenMs = parseIsoDate(entry.lastSeen ?? null);
+  if (Number.isFinite(lastSeenMs)) {
+    return now - lastSeenMs <= HEARTBEAT_ACTIVE_WINDOW_MS + PRESENCE_GRACE_BUFFER_MS;
+  }
+
+  return true;
+};

--- a/src/utils/useArenaPresence.ts
+++ b/src/utils/useArenaPresence.ts
@@ -3,6 +3,7 @@ import { doc, getDoc, type FirestoreError, type Unsubscribe } from "firebase/fir
 import { ensureAnonAuth, watchArenaPresence, db } from "../firebase";
 import { useAuth } from "../context/AuthContext";
 import type { ArenaPresenceEntry } from "../types/models";
+import { isPresenceEntryActive } from "./presenceThresholds";
 
 const presenceDisplayNameCache = new Map<string, string>();
 const loggedPresenceDisplayNames = new Set<string>();
@@ -53,12 +54,7 @@ const collectMissingPlayerIds = (entries: ArenaPresenceEntry[]): string[] => {
 
 const filterActiveEntries = (entries: ArenaPresenceEntry[]): ArenaPresenceEntry[] => {
   const now = Date.now();
-  return entries.filter((entry) => {
-    if (!entry.lastSeen) return true;
-    const parsed = Date.parse(entry.lastSeen);
-    if (!Number.isFinite(parsed)) return true;
-    return now - parsed <= 20_000;
-  });
+  return entries.filter((entry) => isPresenceEntryActive(entry, now));
 };
 
 export const primePresenceDisplayNameCache = (


### PR DESCRIPTION
## Summary
- share presence tolerance helpers so watchers, the host loop, and runtime all honor server expireAt timestamps plus a 60s grace window
- ensure writer election ignores offline writers and document the heartbeat/presence thresholds for QA along with fixing a duplicate type field

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d07e1a4454832ea7ab0d516988bafd