### PR TITLE
Refine arena presence identifiers and roster handling

### DIFF
--- a/src/game/net/hostLoop.test.ts
+++ b/src/game/net/hostLoop.test.ts
@@ -47,8 +47,20 @@ describe("startHostLoop combat", () => {
 
       const nowIso = new Date().toISOString();
       presenceCallback?.([
-        { playerId: "p1", authUid: "p1", codename: "Alpha", lastSeen: nowIso } as ArenaPresenceEntry,
-        { playerId: "p2", authUid: "p2", codename: "Beta", lastSeen: nowIso } as ArenaPresenceEntry,
+        {
+          presenceId: "p1",
+          playerId: "p1",
+          authUid: "p1",
+          codename: "Alpha",
+          lastSeen: nowIso,
+        } as ArenaPresenceEntry,
+        {
+          presenceId: "p2",
+          playerId: "p2",
+          authUid: "p2",
+          codename: "Beta",
+          lastSeen: nowIso,
+        } as ArenaPresenceEntry,
       ]);
 
       const commands: Record<string, ArenaInputSnapshot> = {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -22,6 +22,7 @@ export interface Arena {
 }
 
 export interface ArenaPresenceEntry {
+  presenceId: string;
   playerId: string;
   codename: string;
   displayName?: string | null;

--- a/src/utils/presenceThresholds.ts
+++ b/src/utils/presenceThresholds.ts
@@ -16,15 +16,15 @@ export const isPresenceEntryActive = (
   entry: ArenaPresenceEntry,
   now: number = Date.now(),
 ): boolean => {
-  const expireAtMs = parseIsoDate(entry.expireAt ?? null);
-  if (Number.isFinite(expireAtMs) && now <= expireAtMs + PRESENCE_GRACE_BUFFER_MS) {
-    return true;
-  }
-
   const lastSeenMs = parseIsoDate(entry.lastSeen ?? null);
   if (Number.isFinite(lastSeenMs)) {
-    return now - lastSeenMs <= HEARTBEAT_ACTIVE_WINDOW_MS + PRESENCE_GRACE_BUFFER_MS;
+    return now - lastSeenMs <= HEARTBEAT_ACTIVE_WINDOW_MS;
   }
 
-  return true;
+  const expireAtMs = parseIsoDate(entry.expireAt ?? null);
+  if (Number.isFinite(expireAtMs)) {
+    return now <= expireAtMs;
+  }
+
+  return false;
 };

--- a/src/utils/sessionId.ts
+++ b/src/utils/sessionId.ts
@@ -1,0 +1,40 @@
+const randomSuffix = (): string => Math.random().toString(16).slice(2, 10);
+
+const buildPresenceId = (authUid: string): string => {
+  const globalCrypto = typeof globalThis !== "undefined" ? (globalThis.crypto as Crypto | undefined) : undefined;
+  const base = typeof globalCrypto?.randomUUID === "function" ? globalCrypto.randomUUID() : randomSuffix();
+  const suffix = base.replace(/-/g, "").slice(0, 8) || randomSuffix();
+  return `${authUid}-${suffix}`;
+};
+
+export const loadTabPresenceId = (authUid: string): string => {
+  if (!authUid) {
+    throw new Error("authUid is required to compute presenceId");
+  }
+
+  if (typeof window === "undefined") {
+    return buildPresenceId(authUid);
+  }
+
+  const storage = window.sessionStorage;
+  const key = `presenceId:${authUid}`;
+
+  try {
+    const cached = storage.getItem(key);
+    if (cached && cached.startsWith(`${authUid}-`)) {
+      return cached;
+    }
+  } catch (error) {
+    console.warn("[PRESENCE] sessionStorage get failed", error);
+  }
+
+  const next = buildPresenceId(authUid);
+
+  try {
+    storage.setItem(key, next);
+  } catch (error) {
+    console.warn("[PRESENCE] sessionStorage set failed", error);
+  }
+
+  return next;
+};


### PR DESCRIPTION
## Summary
- add a tab-scoped presence ID helper that persists IDs in sessionStorage
- update arena presence join/heartbeat flows to carry both auth and presence IDs, log chosen names, and surface presenceId on listener payloads
- tighten presence activity filtering, debounce roster updates/logging, and teach ArenaPage to reuse the tab presenceId while priming display-name caches

## Testing
- `pnpm run typecheck` *(fails: vitest types missing in src/game/net/hostLoop.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d08a6b37e8832eb85af50c335d7110