### PR TITLE
Add leaderboard composite index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "arenaId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "leaderboard",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "wins", "order": "DESCENDING" },
+        { "fieldPath": "lastWinAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- add a composite index definition for leaderboard queries ordering by wins and lastWinAt

## Testing
- `firebase deploy --only firestore:indexes` *(fails: firebase CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08a8e3358832e963714630a850154