### PR TITLE
Add build metadata badge and deploy verification

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set build metadata
+        run: |
+          echo "VITE_COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "VITE_COMMIT_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          echo "VITE_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -29,6 +35,21 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+        env:
+          VITE_COMMIT_SHA: ${{ env.VITE_COMMIT_SHA }}
+          VITE_COMMIT_SHORT: ${{ env.VITE_COMMIT_SHORT }}
+          VITE_BUILD_TIME: ${{ env.VITE_BUILD_TIME }}
+
+      - name: Write /dist/version.json (no cache)
+        run: |
+          mkdir -p dist
+          cat > dist/version.json <<'JSON'
+          {
+            "commit": "${{ env.VITE_COMMIT_SHA }}",
+            "short": "${{ env.VITE_COMMIT_SHORT }}",
+            "builtAt": "${{ env.VITE_BUILD_TIME }}"
+          }
+          JSON
 
       - name: Install firebase-tools
         run: npm i -g firebase-tools@14
@@ -46,3 +67,16 @@ jobs:
           SITE_ID: ${{ vars.FIREBASE_SITE || 'stickfightpa' }}
         run: |
           firebase deploy --only hosting --project "$PROJECT_ID" --site "$SITE_ID"
+
+      - name: Hit live /version.json
+        run: |
+          curl -fsS https://stickfightpa.web.app/version.json -o live.json
+          cat live.json
+          echo "EXPECTED=${{ env.VITE_COMMIT_SHA }}" >> $GITHUB_ENV
+
+      - name: Verify live commit matches this build
+        run: |
+          ACTUAL=$(jq -r .commit live.json)
+          echo "expected=$EXPECTED"
+          echo "actual=$ACTUAL"
+          test "$ACTUAL" = "$EXPECTED"

--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,9 @@
     "site": "stickfightpa",
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "headers": [
+      { "source": "/version.json", "headers": [{ "key": "Cache-Control", "value": "no-store" }] }
+    ],
     "rewrites": [{ "source": "**", "destination": "/index.html" }]
   }
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 
+import BuildBadge from "./BuildBadge";
+
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   isActive ? "active" : undefined;
 
@@ -27,6 +29,7 @@ const AppShell = () => {
       <footer className="footer">
         <span className="muted">stickfightpa · Firestore · Anonymous auth</span>
       </footer>
+      <BuildBadge />
     </div>
   );
 };

--- a/src/components/BuildBadge.tsx
+++ b/src/components/BuildBadge.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default function BuildBadge() {
+  const sha = import.meta.env.VITE_COMMIT_SHORT ?? "dev";
+  const builtAt = import.meta.env.VITE_BUILD_TIME ?? "";
+
+  return (
+    <div className="fixed bottom-2 right-2 text-[10px] opacity-70 select-none">
+      build {sha} · {builtAt}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- export build metadata during CI and pass it into the Vite build
- publish a non-cached version.json and verify the deployed commit after firebase deploy
- show the build commit and timestamp in the app shell footer

## Testing
- npm run build *(fails: existing TypeScript errors in src/firebase.ts and src/net/ActionBus.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d0dbdf4900832ea3cf172bf21822a4