### PR TITLE
feat(canary): force all site text red + RED CANARY ACTIVE badge to verify CI deploy to stickfightpa

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
 import AppShell from "./components/AppShell";
+import CanaryBadge from "./components/CanaryBadge";
 import HomePage from "./pages/HomePage";
 import AdminPage from "./pages/AdminPage";
 import ArenaPage from "./pages/ArenaPage";
@@ -11,22 +12,25 @@ import NotFoundPage from "./pages/NotFoundPage";
 
 export default function App() {
   return (
-    <Routes>
-      <Route element={<AppShell />}>
-        <Route path="/" element={<HomePage />} />
-        {/* legacy /index should work */}
-        <Route path="/index" element={<Navigate to="/" replace />} />
-        {/* alternative lobby entry point */}
-        <Route path="/lobby" element={<HomePage />} />
-        {/* SPA admin (separate from legacy /admin.html) */}
-        <Route path="/admin" element={<AdminPage />} />
-        <Route path="/arena/:arenaId" element={<ArenaPage />} />
-        <Route path="/debug/arena/:arenaId" element={<DebugArenaStatePage />} />
-        {/* the one we need */}
-        <Route path="/training" element={<TrainingPage />} />
-        {/* catch-all */}
-        <Route path="*" element={<NotFoundPage />} />
-      </Route>
-    </Routes>
+    <>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/" element={<HomePage />} />
+          {/* legacy /index should work */}
+          <Route path="/index" element={<Navigate to="/" replace />} />
+          {/* alternative lobby entry point */}
+          <Route path="/lobby" element={<HomePage />} />
+          {/* SPA admin (separate from legacy /admin.html) */}
+          <Route path="/admin" element={<AdminPage />} />
+          <Route path="/arena/:arenaId" element={<ArenaPage />} />
+          <Route path="/debug/arena/:arenaId" element={<DebugArenaStatePage />} />
+          {/* the one we need */}
+          <Route path="/training" element={<TrainingPage />} />
+          {/* catch-all */}
+          <Route path="*" element={<NotFoundPage />} />
+        </Route>
+      </Routes>
+      <CanaryBadge />
+    </>
   );
 }

--- a/src/components/CanaryBadge.tsx
+++ b/src/components/CanaryBadge.tsx
@@ -1,0 +1,18 @@
+export default function CanaryBadge() {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 8,
+        right: 8,
+        zIndex: 99999,
+        padding: "6px 8px",
+        border: "1px dashed #ff0000",
+        background: "rgba(255,0,0,0.07)",
+        fontSize: 10,
+      }}
+    >
+      RED CANARY ACTIVE
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "./red-canary.css";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";

--- a/src/red-canary.css
+++ b/src/red-canary.css
@@ -1,0 +1,3 @@
+/* Canary: force all text red so deploys are obvious */
+html, body, #root { color: #ff0000 !important; }
+* { color: #ff0000 !important; }


### PR DESCRIPTION
## Summary
- add a red canary stylesheet that forces all rendered text to display in red
- import the stylesheet at the app entry point so it wins the cascade across the site
- introduce a persistent RED CANARY ACTIVE badge to make deployments visually obvious

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0dcf91454832ebb7e3856f2642085