### PR TITLE
Fix Firestore presence helpers

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -26,6 +26,8 @@ import {
   runTransaction,
   type QueryDocumentSnapshot,
   type Unsubscribe,
+  type Firestore,
+  type DocumentData,
 } from "firebase/firestore";
 
 // === CONFIG (stickfightpa) ===
@@ -418,15 +420,16 @@ export const getArena = async (arenaId: string): Promise<Arena | null> => {
   } as Arena;
 };
 
-export const joinArena = async (
+async function joinArenaWithDb(
+  database: Firestore,
   arenaId: string,
   ids: { authUid: string; presenceId: string },
   codename: string,
   profileId?: string,
   displayName?: string | null,
-) => {
+) {
   const { authUid, presenceId } = ids;
-  const ref = doc(db, `arenas/${arenaId}/presence/${presenceId}`);
+  const ref = doc(database, `arenas/${arenaId}/presence/${presenceId}`);
   const trimmedDisplayName =
     typeof displayName === "string" && displayName.trim().length > 0 ? displayName.trim() : null;
   const playerId = profileId ?? presenceId;
@@ -473,17 +476,26 @@ export const joinArena = async (
     ...baseData,
     ...heartbeatData,
   });
-};
+}
 
-export const heartbeatArenaPresence = async (
+export const joinArena = async (
   arenaId: string,
   ids: { authUid: string; presenceId: string },
   codename: string,
   profileId?: string,
   displayName?: string | null,
-) => {
+) => joinArenaWithDb(db, arenaId, ids, codename, profileId, displayName);
+
+async function heartbeatArenaPresenceWithDb(
+  database: Firestore,
+  arenaId: string,
+  ids: { authUid: string; presenceId: string },
+  codename: string,
+  profileId?: string,
+  displayName?: string | null,
+) {
   const { authUid, presenceId } = ids;
-  const ref = doc(db, `arenas/${arenaId}/presence/${presenceId}`);
+  const ref = doc(database, `arenas/${arenaId}/presence/${presenceId}`);
   const trimmedDisplayName =
     typeof displayName === "string" && displayName.trim().length > 0 ? displayName.trim() : null;
   const playerId = profileId ?? presenceId;
@@ -519,7 +531,16 @@ export const heartbeatArenaPresence = async (
     }
     throw error;
   }
-};
+}
+
+export const heartbeatArenaPresence = async (
+  arenaId: string,
+  ids: { authUid: string; presenceId: string },
+  codename: string,
+  profileId?: string,
+  displayName?: string | null,
+) =>
+  heartbeatArenaPresenceWithDb(db, arenaId, ids, codename, profileId, displayName);
 
 export const leaveArena = async (arenaId: string, presenceId: string) => {
   await deleteDoc(doc(db, `arenas/${arenaId}/presence/${presenceId}`));
@@ -643,51 +664,139 @@ export const watchArenaSeats = (
   });
 };
 
+type PresenceDocumentShape = {
+  playerId?: unknown;
+  codename?: unknown;
+  displayName?: unknown;
+  authUid?: unknown;
+  profileId?: unknown;
+  joinedAt?: unknown;
+  lastSeen?: unknown;
+  expireAt?: unknown;
+};
+
+const normalizePresenceString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const readPresenceTimestamp = (value: unknown): ISODate | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const date = (value as { toDate?: () => Date }).toDate?.();
+  return date?.toISOString();
+};
+
+export interface LivePresence extends ArenaPresenceEntry {}
+
+const toLivePresence = (snap: QueryDocumentSnapshot<DocumentData>): LivePresence => {
+  const data = snap.data() as PresenceDocumentShape;
+  const presenceId = snap.id;
+  const playerId = normalizePresenceString(data.playerId) ?? presenceId;
+  const codename = normalizePresenceString(data.codename) ?? "Agent";
+  const displayName = normalizePresenceString(data.displayName);
+  const authUid = normalizePresenceString(data.authUid) ?? presenceId;
+  const profileId = normalizePresenceString(data.profileId);
+
+  return {
+    presenceId,
+    playerId,
+    codename,
+    displayName,
+    joinedAt: readPresenceTimestamp(data.joinedAt),
+    authUid,
+    profileId,
+    lastSeen: readPresenceTimestamp(data.lastSeen),
+    expireAt: readPresenceTimestamp(data.expireAt),
+  };
+};
+
 export const watchArenaPresence = (
+  database: Firestore,
   arenaId: string,
-  cb: (players: ArenaPresenceEntry[]) => void,
+  cb: (players: LivePresence[]) => void,
 ): Unsubscribe => {
   const presenceRef = query(
-    collection(db, `arenas/${arenaId}/presence`),
+    collection(database, `arenas/${arenaId}/presence`),
     orderBy("joinedAt", "asc"),
   );
   return onSnapshot(presenceRef, (snapshot) => {
-    const players = snapshot.docs.map((docSnap) => {
-      const data = docSnap.data() as any;
-      const presenceId = docSnap.id;
-      const displayName =
-        typeof data.displayName === "string" && data.displayName.trim().length > 0
-          ? data.displayName.trim()
-          : undefined;
-      const authUid =
-        typeof data.authUid === "string" && data.authUid.trim().length > 0
-          ? data.authUid.trim()
-          : undefined;
-      return {
-return {
-  presenceId: docSnap.id,                  // ✅ doc id on READ
-  playerId: data.playerId ?? docSnap.id,
-  codename: data.codename ?? "Agent",
-  displayName,
-  joinedAt: data.joinedAt?.toDate?.().toISOString?.(),
-  authUid: typeof data.authUid === "string" ? data.authUid : undefined, // ✅ read from data
-  profileId: data.profileId,
-  lastSeen: data.lastSeen?.toDate?.().toISOString?.(),
-  expireAt: data.expireAt?.toDate?.().toISOString?.(),
-} as ArenaPresenceEntry;
-        playerId: data.playerId ?? docSnap.id,
-        codename: data.codename ?? "Agent",
-        displayName,
-        joinedAt: data.joinedAt?.toDate?.().toISOString?.(),
-        authUid: authUid ?? presenceId,
-        profileId: data.profileId,
-        lastSeen: data.lastSeen?.toDate?.().toISOString?.(),
-        expireAt: data.expireAt?.toDate?.().toISOString?.(),
-      } as ArenaPresenceEntry;
-    });
-    cb(players);
+    cb(snapshot.docs.map((docSnap) => toLivePresence(docSnap)));
   });
 };
+
+export interface PresenceHeartbeatOptions {
+  arenaId: string;
+  ids: { authUid: string; presenceId: string };
+  codename: string;
+  profileId?: string;
+  displayName?: string | null;
+  intervalMs?: number;
+  logger?: Pick<typeof console, "warn" | "info" | "error">;
+}
+
+export function startPresenceHeartbeat(
+  database: Firestore,
+  options: PresenceHeartbeatOptions,
+): () => void {
+  const { arenaId, ids, codename, profileId, displayName } = options;
+  const intervalMs = Math.max(1_000, options.intervalMs ?? 20_000);
+  const logger = options.logger ?? console;
+
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const runHeartbeat = async () => {
+    if (stopped) return;
+    try {
+      await heartbeatArenaPresenceWithDb(
+        database,
+        arenaId,
+        ids,
+        codename,
+        profileId,
+        displayName ?? null,
+      );
+    } catch (error) {
+      logger.warn?.(
+        `[PRESENCE] heartbeat tick failed for arena=${arenaId} presence=${ids.presenceId}`,
+        error,
+      );
+    }
+  };
+
+  (async () => {
+    try {
+      await joinArenaWithDb(
+        database,
+        arenaId,
+        ids,
+        codename,
+        profileId,
+        displayName ?? null,
+      );
+      if (stopped) return;
+      await runHeartbeat();
+      if (stopped) return;
+      timer = setInterval(() => {
+        void runHeartbeat();
+      }, intervalMs);
+    } catch (error) {
+      logger.warn?.(
+        `[PRESENCE] failed to start heartbeat for arena=${arenaId} presence=${ids.presenceId}`,
+        error,
+      );
+    }
+  })();
+
+  return () => {
+    stopped = true;
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
 
 const arenaStateDoc = (arenaId: string) =>
   doc(db, "arenas", arenaId, "state", "current");
@@ -812,22 +921,6 @@ export async function writeArenaInput(
 
   await setDoc(ref, payload, { merge: true });
 }
-
-
-    updatedAt: serverTimestamp(),
-  };
-  if (typeof input.authUid === "string" && input.authUid.length > 0) {
-    payload.authUid = input.authUid;
-  }
-  if (typeof input.left === "boolean") payload.left = input.left;
-  if (typeof input.right === "boolean") payload.right = input.right;
-  if (typeof input.jump === "boolean") payload.jump = input.jump;
-  if (typeof input.attack === "boolean") payload.attack = input.attack;
-  if (typeof input.attackSeq === "number") payload.attackSeq = input.attackSeq;
-  if (input.codename) payload.codename = input.codename;
-  await setDoc(ref, payload, { merge: true });
-}
-
 export async function deleteArenaInput(arenaId: string, presenceId: string): Promise<void> {
   await ensureAnonAuth();
   const ref = arenaInputDoc(arenaId, presenceId);

--- a/src/game/net/hostLoop.test.ts
+++ b/src/game/net/hostLoop.test.ts
@@ -16,8 +16,9 @@ const writeArenaStateMock = vi.fn(async () => {
 });
 
 vi.mock("../../firebase", () => ({
+  db: {} as unknown,
   watchArenaPresence: vi.fn(
-    (_arenaId: string, cb: (entries: ArenaPresenceEntry[]) => void) => {
+    (_db: unknown, _arenaId: string, cb: (entries: ArenaPresenceEntry[]) => void) => {
       presenceCallback = cb;
       return () => undefined;
     },

--- a/src/game/net/hostLoop.ts
+++ b/src/game/net/hostLoop.ts
@@ -1,4 +1,5 @@
 import {
+  db,
   watchArenaInputs,
   watchArenaPresence,
   writeArenaState,
@@ -348,7 +349,7 @@ export function startHostLoop(options: HostLoopOptions): HostLoopController {
     }
   };
 
-  presenceUnsub = watchArenaPresence(options.arenaId, handlePresence);
+  presenceUnsub = watchArenaPresence(db, options.arenaId, handlePresence);
   inputsUnsub = watchArenaInputs(options.arenaId, handleInputs);
 
   timer = setInterval(() => {

--- a/src/utils/useArenaPresence.ts
+++ b/src/utils/useArenaPresence.ts
@@ -163,7 +163,7 @@ export function useArenaPresence(arenaId?: string): UseArenaPresenceResult {
         setError(null);
         await ensureAnonAuth();
         if (cancelled) return;
-        unsub = watchArenaPresence(arenaId, (entries) => {
+        unsub = watchArenaPresence(db, arenaId, (entries) => {
           if (cancelled) return;
           const currentGen = ++generation;
           latestEntries = filterActiveEntries(entries);


### PR DESCRIPTION
## Summary
- refactor arena presence join and heartbeat helpers to work with an injected Firestore instance
- add a typed LivePresence converter, updated watchArenaPresence, and a startPresenceHeartbeat utility
- update consumers and tests to use the new watchArenaPresence signature and clean up stray code

## Testing
- pnpm run typecheck *(fails: src/net/ActionBus.ts:102:1 - error TS1005: ')' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e0b9e86c832eba90f4d3ac9c67c2