### PR TITLE
Rebuild action bus to enqueue arena inputs

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -664,18 +664,8 @@ export const watchArenaPresence = (
           ? data.authUid.trim()
           : undefined;
       return {
-return {
-  presenceId: docSnap.id,                  // ✅ doc id on READ
-  playerId: data.playerId ?? docSnap.id,
-  codename: data.codename ?? "Agent",
-  displayName,
-  joinedAt: data.joinedAt?.toDate?.().toISOString?.(),
-  authUid: typeof data.authUid === "string" ? data.authUid : undefined, // ✅ read from data
-  profileId: data.profileId,
-  lastSeen: data.lastSeen?.toDate?.().toISOString?.(),
-  expireAt: data.expireAt?.toDate?.().toISOString?.(),
-} as ArenaPresenceEntry;
-        playerId: data.playerId ?? docSnap.id,
+        presenceId,
+        playerId: data.playerId ?? presenceId,
         codename: data.codename ?? "Agent",
         displayName,
         joinedAt: data.joinedAt?.toDate?.().toISOString?.(),
@@ -774,58 +764,6 @@ export function watchArenaState(arenaId: string, cb: (state: any) => void) {
       unsubscribe = null;
     }
   };
-}
-
-export interface ArenaInputWrite {
-  presenceId: string;
-  authUid?: string;
-  left?: boolean;
-  right?: boolean;
-  jump?: boolean;
-  attack?: boolean;
-  codename?: string;
-  attackSeq?: number;
-}
-
-export async function writeArenaInput(
-  arenaId: string,
-  input: ArenaInputWrite
-): Promise<void> {
-  await ensureAnonAuth();
-
-  const uid = auth.currentUser?.uid;
-  if (!uid) throw new Error("No authenticated user");
-
-  const ref = arenaInputDoc(arenaId, input.presenceId);
-  const payload: Record<string, unknown> = {
-    playerId: input.presenceId,
-    presenceId: input.presenceId,
-    authUid: uid, // satisfies rules: request.resource.data.authUid == request.auth.uid
-    left: input.left,
-    right: input.right,
-    jump: input.jump,
-    attack: input.attack,
-    codename: input.codename,
-    attackSeq: input.attackSeq,
-    updatedAt: serverTimestamp(),
-  };
-
-  await setDoc(ref, payload, { merge: true });
-}
-
-
-    updatedAt: serverTimestamp(),
-  };
-  if (typeof input.authUid === "string" && input.authUid.length > 0) {
-    payload.authUid = input.authUid;
-  }
-  if (typeof input.left === "boolean") payload.left = input.left;
-  if (typeof input.right === "boolean") payload.right = input.right;
-  if (typeof input.jump === "boolean") payload.jump = input.jump;
-  if (typeof input.attack === "boolean") payload.attack = input.attack;
-  if (typeof input.attackSeq === "number") payload.attackSeq = input.attackSeq;
-  if (input.codename) payload.codename = input.codename;
-  await setDoc(ref, payload, { merge: true });
 }
 
 export async function deleteArenaInput(arenaId: string, presenceId: string): Promise<void> {

--- a/src/net/ActionBus.ts
+++ b/src/net/ActionBus.ts
@@ -1,4 +1,8 @@
-import { deleteArenaInput, writeArenaInput, type ArenaInputWrite } from "../firebase";
+import type { FirebaseApp } from "firebase/app";
+import type { Firestore } from "firebase/firestore";
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
+import { app, db, deleteArenaInput, ensureAnonAuth } from "../firebase";
 
 const THROTTLE_MS = 60;
 
@@ -21,13 +25,13 @@ interface NormalizedInput {
 
 interface InitOptions {
   arenaId: string;
-  presenceId: string;   // per-tab session id
+  presenceId: string; // per-tab session id
   codename?: string;
 }
 
 interface ActionBusState {
   arenaId: string;
-  presenceId: string;   // per-tab session id
+  presenceId: string; // per-tab session id
   codename?: string;
   ready: boolean;
   lastSendAt: number;
@@ -37,7 +41,49 @@ interface ActionBusState {
   pendingTimer?: ReturnType<typeof setTimeout>;
 }
 
+interface InputPayload {
+  left?: boolean;
+  right?: boolean;
+  jump?: boolean;
+  attack?: boolean;
+  codename?: string;
+  attackSeq?: number;
+}
+
 let busState: ActionBusState | null = null;
+
+async function writeArenaInput(
+  firestore: Firestore,
+  firebaseApp: FirebaseApp,
+  arenaId: string,
+  presenceId: string,
+  payload: InputPayload,
+): Promise<void> {
+  await ensureAnonAuth();
+
+  const auth = getAuth(firebaseApp);
+  const uid = auth.currentUser?.uid;
+  if (!uid) {
+    throw new Error("No authenticated user");
+  }
+
+  const ref = doc(firestore, "arenas", arenaId, "inputs", presenceId);
+  const data: Record<string, unknown> = {
+    playerId: presenceId,
+    presenceId,
+    authUid: uid,
+    updatedAt: serverTimestamp(),
+  };
+
+  if (typeof payload.left === "boolean") data.left = payload.left;
+  if (typeof payload.right === "boolean") data.right = payload.right;
+  if (typeof payload.jump === "boolean") data.jump = payload.jump;
+  if (typeof payload.attack === "boolean") data.attack = payload.attack;
+  if (typeof payload.attackSeq === "number") data.attackSeq = payload.attackSeq;
+  if (typeof payload.codename === "string") data.codename = payload.codename;
+
+  await setDoc(ref, data, { merge: true });
+}
 
 const defaultInput: NormalizedInput = {
   left: false,
@@ -72,9 +118,8 @@ function inputsEqual(a?: NormalizedInput, b?: NormalizedInput): boolean {
   );
 }
 
-function toWritePayload(state: ActionBusState, input: NormalizedInput): ArenaInputWrite {
+function toWritePayload(state: ActionBusState, input: NormalizedInput): InputPayload {
   return {
-    presenceId: state.presenceId,
     left: input.left,
     right: input.right,
     jump: input.jump,
@@ -92,10 +137,100 @@ async function sendInput(state: ActionBusState, payload: NormalizedInput) {
   try {
     const seq = payload.attackSeq;
     console.info("[INPUT] write", { presenceId: state.presenceId, seq });
-    await writeArenaInput(state.arenaId, toWritePayload(state, payload));
+    await writeArenaInput(db, app, state.arenaId, state.presenceId, toWritePayload(state, payload));
   } catch (error) {
     console.warn("[INPUT] rejected", { presenceId: state.presenceId, error });
   }
 }
 
-function scheduleSend(state: ActionBus
+function scheduleSend(state: ActionBusState, payload: NormalizedInput) {
+  const now = Date.now();
+  const elapsed = now - state.lastSendAt;
+
+  if (elapsed >= THROTTLE_MS) {
+    void sendInput(state, payload);
+    return;
+  }
+
+  state.pendingPayload = cloneNormalized(payload);
+
+  if (state.pendingTimer) {
+    return;
+  }
+
+  const delay = Math.max(THROTTLE_MS - elapsed, 0);
+  state.pendingTimer = setTimeout(() => {
+    state.pendingTimer = undefined;
+    const pending = state.pendingPayload;
+    if (!pending) return;
+    state.pendingPayload = undefined;
+    void sendInput(state, pending);
+  }, delay);
+}
+
+export async function initActionBus(options: InitOptions): Promise<void> {
+  disposeActionBus();
+
+  const initialInput = cloneNormalized(defaultInput);
+  const state: ActionBusState = {
+    arenaId: options.arenaId,
+    presenceId: options.presenceId,
+    codename: options.codename,
+    ready: false,
+    lastSendAt: 0,
+    latestInput: initialInput,
+  };
+
+  busState = state;
+
+  try {
+    await writeArenaInput(db, app, state.arenaId, state.presenceId, toWritePayload(state, initialInput));
+    state.lastSentPayload = cloneNormalized(initialInput);
+    state.lastSendAt = Date.now();
+  } catch (error) {
+    console.warn("[INPUT] init write failed", { presenceId: state.presenceId, error });
+  } finally {
+    state.ready = true;
+  }
+}
+
+export function publishInput(input: PlayerInput): void {
+  const state = busState;
+  if (!state || !state.ready) return;
+
+  if (typeof input.codename === "string" && input.codename.length > 0) {
+    state.codename = input.codename;
+  }
+
+  const normalized = normalizeInput(input, state.latestInput ?? defaultInput);
+  if (inputsEqual(normalized, state.latestInput)) {
+    return;
+  }
+
+  state.latestInput = cloneNormalized(normalized);
+
+  if (inputsEqual(normalized, state.lastSentPayload)) {
+    return;
+  }
+
+  scheduleSend(state, normalized);
+}
+
+export function disposeActionBus(): void {
+  const state = busState;
+  if (!state) return;
+
+  if (state.pendingTimer) {
+    clearTimeout(state.pendingTimer);
+  }
+
+  busState = null;
+
+  void (async () => {
+    try {
+      await deleteArenaInput(state.arenaId, state.presenceId);
+    } catch (error) {
+      console.warn("[INPUT] delete failed", { presenceId: state.presenceId, error });
+    }
+  })();
+}


### PR DESCRIPTION
## Summary
- rebuild the action bus to use a typed Firestore writer that enqueues arena inputs with authentication metadata
- restore the original throttling and lifecycle helpers so input publishing works with the updated write signature
- clean up the Firebase presence watcher and remove the obsolete writeArenaInput helper

## Testing
- pnpm run typecheck *(fails: existing Vitest typings are missing beforeEach/afterEach/vi exports and leave implicit any params)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e0c78274832e9cb690e980a89bf5