### PR TITLE
Add TypeScript type check to Firebase Hosting workflow

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -65,6 +65,9 @@ jobs:
               ;;
           esac
 
+      - name: Type Check
+        run: npx tsc -p tsconfig.build.json --noEmit
+
       - name: Build
         run: npm run build
         env:


### PR DESCRIPTION
## Summary
- add a TypeScript compile step to the Firebase Hosting workflow so type errors block deployments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0e0d5e768832e9c3fa95f3b4053b2