### PR TITLE
Update Firebase hosting workflow smoke test

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -103,15 +103,7 @@ jobs:
         run: |
           firebase deploy --only hosting --project "$PROJECT_ID" --site "$SITE_ID"
 
-      - name: Hit live /version.json
+      - name: Smoke test: canary present on home
         run: |
-          curl -fsS https://stickfightpa.web.app/version.json -o live.json
-          cat live.json
-          echo "EXPECTED=${{ env.VITE_COMMIT_SHA }}" >> $GITHUB_ENV
-
-      - name: Verify live commit matches this build
-        run: |
-          ACTUAL=$(jq -r .commit live.json)
-          echo "expected=$EXPECTED"
-          echo "actual=$ACTUAL"
-          test "$ACTUAL" = "$EXPECTED"
+          curl -fsS https://stickfightpa.web.app/ -o home.html
+          grep -q "RED CANARY ACTIVE" home.html || (echo "Canary not found on live site" && exit 1)


### PR DESCRIPTION
## Summary
- remove the version.json verification steps that curl the deployed site
- add a smoke test to ensure the RED CANARY ACTIVE marker appears on the live home page after deploy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0e544566c832ea9da0acc7e27c4b2