### PR TITLE
Refactor presence helpers and input publishing

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -664,137 +664,57 @@ export const watchArenaSeats = (
   });
 };
 
-type PresenceDocumentShape = {
-  playerId?: unknown;
-  codename?: unknown;
-  displayName?: unknown;
-  authUid?: unknown;
-  profileId?: unknown;
-  joinedAt?: unknown;
-  lastSeen?: unknown;
-  expireAt?: unknown;
-};
+export type LivePresence = {
+  id: string;
+  authUid: string;
+  lastSeen: number;
+  presenceId?: string;
+} & DocumentData;
 
-const normalizePresenceString = (value: unknown): string | undefined => {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-};
+export const PRESENCE_STALE_MS = 20_000; // lastSeen ≤ 20s
+export const HEARTBEAT_MS = 10_000; // write heartbeat every 10s
 
-const readPresenceTimestamp = (value: unknown): ISODate | undefined => {
-  if (!value || typeof value !== "object") return undefined;
-  const date = (value as { toDate?: () => Date }).toDate?.();
-  return date?.toISOString();
-};
-
-export interface LivePresence extends ArenaPresenceEntry {}
-
-const toLivePresence = (snap: QueryDocumentSnapshot<DocumentData>): LivePresence => {
-  const data = snap.data() as PresenceDocumentShape;
-  const presenceId = snap.id;
-  const playerId = normalizePresenceString(data.playerId) ?? presenceId;
-  const codename = normalizePresenceString(data.codename) ?? "Agent";
-  const displayName = normalizePresenceString(data.displayName);
-  const authUid = normalizePresenceString(data.authUid) ?? presenceId;
-  const profileId = normalizePresenceString(data.profileId);
-
-  return {
-    presenceId,
-    playerId,
-    codename,
-    displayName,
-    joinedAt: readPresenceTimestamp(data.joinedAt),
-    authUid,
-    profileId,
-    lastSeen: readPresenceTimestamp(data.lastSeen),
-    expireAt: readPresenceTimestamp(data.expireAt),
-  };
-};
-
-export const watchArenaPresence = (
+export function watchArenaPresence(
   database: Firestore,
   arenaId: string,
-  cb: (players: LivePresence[]) => void,
-): Unsubscribe => {
-  const presenceRef = query(
-    collection(database, `arenas/${arenaId}/presence`),
-    orderBy("joinedAt", "asc"),
-  );
-  return onSnapshot(presenceRef, (snapshot) => {
-    cb(snapshot.docs.map((docSnap) => toLivePresence(docSnap)));
-  });
-};
+  onChange: (live: LivePresence[]) => void,
+) {
+  return onSnapshot(collection(database, `arenas/${arenaId}/presence`), (snap) => {
+    const now = Date.now();
+    const live = snap.docs
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as DocumentData) }))
+      .filter((presence: any) => now - (presence.lastSeen ?? 0) <= PRESENCE_STALE_MS) as LivePresence[];
 
-export interface PresenceHeartbeatOptions {
-  arenaId: string;
-  ids: { authUid: string; presenceId: string };
-  codename: string;
-  profileId?: string;
-  displayName?: string | null;
-  intervalMs?: number;
-  logger?: Pick<typeof console, "warn" | "info" | "error">;
+    console.info(`[PRESENCE] live=${live.length} all=${snap.size}`);
+    onChange(live);
+  });
 }
 
 export function startPresenceHeartbeat(
   database: Firestore,
-  options: PresenceHeartbeatOptions,
-): () => void {
-  const { arenaId, ids, codename, profileId, displayName } = options;
-  const intervalMs = Math.max(1_000, options.intervalMs ?? 20_000);
-  const logger = options.logger ?? console;
-
-  let stopped = false;
+  arenaId: string,
+  presenceId: string,
+  authUid: string,
+) {
+  const ref = doc(database, `arenas/${arenaId}/presence/${presenceId}`);
   let timer: ReturnType<typeof setInterval> | null = null;
 
-  const runHeartbeat = async () => {
-    if (stopped) return;
+  const tick = async () => {
     try {
-      await heartbeatArenaPresenceWithDb(
-        database,
-        arenaId,
-        ids,
-        codename,
-        profileId,
-        displayName ?? null,
+      await setDoc(
+        ref,
+        { presenceId, authUid, lastSeen: Date.now() },
+        { merge: true },
       );
     } catch (error) {
-      logger.warn?.(
-        `[PRESENCE] heartbeat tick failed for arena=${arenaId} presence=${ids.presenceId}`,
-        error,
-      );
+      console.info("[PRESENCE] heartbeat error", error);
     }
   };
 
-  (async () => {
-    try {
-      await joinArenaWithDb(
-        database,
-        arenaId,
-        ids,
-        codename,
-        profileId,
-        displayName ?? null,
-      );
-      if (stopped) return;
-      await runHeartbeat();
-      if (stopped) return;
-      timer = setInterval(() => {
-        void runHeartbeat();
-      }, intervalMs);
-    } catch (error) {
-      logger.warn?.(
-        `[PRESENCE] failed to start heartbeat for arena=${arenaId} presence=${ids.presenceId}`,
-        error,
-      );
-    }
-  })();
-
+  void tick();
+  timer = setInterval(tick, HEARTBEAT_MS);
   return () => {
-    stopped = true;
-    if (timer) {
-      clearInterval(timer);
-      timer = null;
-    }
+    if (timer) clearInterval(timer);
   };
 }
 
@@ -913,8 +833,6 @@ export async function writeArenaInput(
     updatedAt: serverTimestamp(),
   };
 
-// assumes: ref: DocumentReference, input: any, payload: Record<string, unknown>
-{
   // stamp only known, correctly-typed fields
   if (typeof input.authUid === "string" && input.authUid.length > 0) {
     payload.authUid = input.authUid;

--- a/src/game/input/inputsChannel.ts
+++ b/src/game/input/inputsChannel.ts
@@ -1,4 +1,4 @@
-import { publishInput } from "../../net/ActionBus";
+import { publishInput } from "../../net/InputPublisher";
 
 export type InputKey = "left" | "right" | "up" | "jump" | "attack1" | "attack2";
 

--- a/src/game/net/hostLoop.ts
+++ b/src/game/net/hostLoop.ts
@@ -4,8 +4,10 @@ import {
   watchArenaPresence,
   writeArenaState,
   type ArenaInputSnapshot,
+  type LivePresence,
 } from "../../firebase";
 import type { ArenaPresenceEntry } from "../../types/models";
+import { mapLivePresenceToArenaEntries } from "../../utils/livePresence";
 
 export interface HostLoopOptions {
   arenaId: string;
@@ -104,8 +106,9 @@ export function startHostLoop(options: HostLoopOptions): HostLoopController {
     return { ...point };
   };
 
-  const handlePresence = (entries: ArenaPresenceEntry[]) => {
+  const handlePresence = (live: LivePresence[]) => {
     if (stopped) return;
+    const entries = mapLivePresenceToArenaEntries(live);
     const now = Date.now();
     const active = new Set<string>();
 

--- a/src/game/net/matchChannel.ts
+++ b/src/game/net/matchChannel.ts
@@ -1,4 +1,4 @@
-import { publishInput } from "../../net/ActionBus";
+import { publishInput } from "../../net/InputPublisher";
 import { createArenaPeerService, type ArenaPeerService, type ArenaStateSnapshot } from "./arenaSync";
 
 export type AuthoritativeSnapshot = ArenaStateSnapshot;

--- a/src/net/ActionBus.ts
+++ b/src/net/ActionBus.ts
@@ -1,101 +1,51 @@
-import { deleteArenaInput, writeArenaInput, type ArenaInputWrite } from "../firebase";
+// src/net/ActionBus.ts
+import type { Firestore } from "firebase/firestore";
+import { addDoc, collection } from "firebase/firestore";
+import type { FirebaseApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
 
-const THROTTLE_MS = 60;
-
-export interface PlayerInput {
+export type InputPayload = {
+  type: string;
   left?: boolean;
   right?: boolean;
   jump?: boolean;
   attack?: boolean;
-  codename?: string;
   attackSeq?: number;
-}
-
-interface NormalizedInput {
-  left: boolean;
-  right: boolean;
-  jump: boolean;
-  attack: boolean;
-  attackSeq: number;
-}
-
-interface InitOptions {
-  arenaId: string;
-  presenceId: string;   // per-tab session id
   codename?: string;
-}
-
-interface ActionBusState {
-  arenaId: string;
-  presenceId: string;   // per-tab session id
-  codename?: string;
-  ready: boolean;
-  lastSendAt: number;
-  lastSentPayload?: NormalizedInput;
-  latestInput: NormalizedInput;
-  pendingPayload?: NormalizedInput;
-  pendingTimer?: ReturnType<typeof setTimeout>;
-}
-
-let busState: ActionBusState | null = null;
-
-const defaultInput: NormalizedInput = {
-  left: false,
-  right: false,
-  jump: false,
-  attack: false,
-  attackSeq: 0,
+  // allow extra flags, but they won't all be persisted
+  [k: string]: unknown;
 };
 
-function normalizeInput(input: PlayerInput, base: NormalizedInput): NormalizedInput {
-  return {
-    left: typeof input.left === "boolean" ? input.left : base.left,
-    right: typeof input.right === "boolean" ? input.right : base.right,
-    jump: typeof input.jump === "boolean" ? input.jump : base.jump,
-    attack: typeof input.attack === "boolean" ? input.attack : base.attack,
-    attackSeq: typeof input.attackSeq === "number" ? input.attackSeq : base.attackSeq,
+/**
+ * Write a single input event under arenas/{arenaId}/inputs/{presenceId}/events
+ * Stamps authUid and clientTs. Validations happen on the host loop.
+ */
+export async function writeArenaInput(
+  db: Firestore,
+  app: FirebaseApp,
+  arenaId: string,
+  presenceId: string,
+  input: InputPayload
+): Promise<void> {
+  const authUid = getAuth(app).currentUser?.uid;
+  if (!authUid) throw new Error("no-auth");
+
+  const events = collection(db, "arenas", arenaId, "inputs", presenceId, "events");
+  const payload: Record<string, unknown> = {
+    type: input.type,
+    presenceId,
+    authUid,
+    clientTs: Date.now(),
+    applied: false,
   };
+
+  if (typeof input.left === "boolean") payload.left = input.left;
+  if (typeof input.right === "boolean") payload.right = input.right;
+  if (typeof input.jump === "boolean") payload.jump = input.jump;
+  if (typeof input.attack === "boolean") payload.attack = input.attack;
+  if (typeof input.attackSeq === "number") payload.attackSeq = input.attackSeq;
+  if (typeof input.codename === "string" && input.codename) payload.codename = input.codename;
+
+  await addDoc(events, payload);
+  console.info("[INPUT] enqueue", { presenceId, type: input.type });
 }
-
-function cloneNormalized(input: NormalizedInput): NormalizedInput {
-  return { ...input };
-}
-
-function inputsEqual(a?: NormalizedInput, b?: NormalizedInput): boolean {
-  if (!a || !b) return false;
-  return (
-    a.left === b.left &&
-    a.right === b.right &&
-    a.jump === b.jump &&
-    a.attack === b.attack &&
-    a.attackSeq === b.attackSeq
-  );
-}
-
-function toWritePayload(state: ActionBusState, input: NormalizedInput): ArenaInputWrite {
-  return {
-    presenceId: state.presenceId,
-    left: input.left,
-    right: input.right,
-    jump: input.jump,
-    attack: input.attack,
-    attackSeq: input.attackSeq,
-    codename: state.codename,
-  };
-}
-
-async function sendInput(state: ActionBusState, payload: NormalizedInput) {
-  state.lastSentPayload = cloneNormalized(payload);
-  state.lastSendAt = Date.now();
-  state.pendingPayload = undefined;
-
-  try {
-    const seq = payload.attackSeq;
-    console.info("[INPUT] write", { presenceId: state.presenceId, seq });
-    await writeArenaInput(state.arenaId, toWritePayload(state, payload));
-  } catch (error) {
-    console.warn("[INPUT] rejected", { presenceId: state.presenceId, error });
-  }
-}
-
-function scheduleSend(state: ActionBus

--- a/src/net/InputPublisher.ts
+++ b/src/net/InputPublisher.ts
@@ -1,0 +1,145 @@
+import { app, db } from "../firebase";
+import { writeArenaInput, type InputPayload } from "./ActionBus";
+
+const THROTTLE_MS = 60;
+
+type PublishContext = {
+  arenaId: string;
+  presenceId: string;
+  codename?: string;
+};
+
+type NormalizedInput = {
+  left: boolean;
+  right: boolean;
+  jump: boolean;
+  attack: boolean;
+  attackSeq: number;
+  codename?: string;
+};
+
+let context: PublishContext | null = null;
+let lastSent: NormalizedInput | null = null;
+let lastSendAt = 0;
+let pending: NormalizedInput | null = null;
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+const defaultState = (): NormalizedInput => ({
+  left: false,
+  right: false,
+  jump: false,
+  attack: false,
+  attackSeq: 0,
+  codename: context?.codename,
+});
+
+const normalizeInput = (
+  input: Partial<NormalizedInput>,
+  base: NormalizedInput,
+): NormalizedInput => ({
+  left: typeof input.left === "boolean" ? input.left : base.left,
+  right: typeof input.right === "boolean" ? input.right : base.right,
+  jump: typeof input.jump === "boolean" ? input.jump : base.jump,
+  attack: typeof input.attack === "boolean" ? input.attack : base.attack,
+  attackSeq: typeof input.attackSeq === "number" ? input.attackSeq : base.attackSeq,
+  codename: typeof input.codename === "string" && input.codename.length > 0 ? input.codename : base.codename,
+});
+
+const inputsEqual = (a: NormalizedInput | null, b: NormalizedInput | null): boolean => {
+  if (!a || !b) return false;
+  return (
+    a.left === b.left &&
+    a.right === b.right &&
+    a.jump === b.jump &&
+    a.attack === b.attack &&
+    a.attackSeq === b.attackSeq &&
+    a.codename === b.codename
+  );
+};
+
+const toPayload = (input: NormalizedInput): InputPayload => ({
+  type: "input",
+  left: input.left,
+  right: input.right,
+  jump: input.jump,
+  attack: input.attack,
+  attackSeq: input.attackSeq,
+  codename: input.codename,
+});
+
+const flushPending = (next: NormalizedInput) => {
+  if (!context) return;
+  pending = null;
+  if (pendingTimer) {
+    clearTimeout(pendingTimer);
+    pendingTimer = null;
+  }
+  lastSent = { ...next };
+  lastSendAt = Date.now();
+
+  const payload = toPayload(next);
+  if (!payload.codename && context.codename) {
+    payload.codename = context.codename;
+  }
+
+  void writeArenaInput(db, app, context.arenaId, context.presenceId, payload).catch((error) => {
+    console.warn("[INPUT] enqueue failed", error);
+  });
+};
+
+const scheduleFlush = (next: NormalizedInput) => {
+  pending = next;
+  if (pendingTimer) return;
+  const delay = Math.max(0, THROTTLE_MS - (Date.now() - lastSendAt));
+  pendingTimer = setTimeout(() => {
+    if (!pending) {
+      pendingTimer = null;
+      return;
+    }
+    const payload = pending;
+    pending = null;
+    pendingTimer = null;
+    flushPending(payload);
+  }, delay);
+};
+
+export const initInputPublisher = (options: PublishContext) => {
+  context = { ...options, codename: options.codename ?? undefined };
+  lastSent = null;
+  lastSendAt = 0;
+  pending = null;
+  if (pendingTimer) {
+    clearTimeout(pendingTimer);
+    pendingTimer = null;
+  }
+};
+
+export const disposeInputPublisher = () => {
+  context = null;
+  lastSent = null;
+  pending = null;
+  if (pendingTimer) {
+    clearTimeout(pendingTimer);
+    pendingTimer = null;
+  }
+};
+
+export const publishInput = (input: Partial<NormalizedInput>) => {
+  if (!context) {
+    return;
+  }
+
+  const base = pending ?? lastSent ?? defaultState();
+  const next = normalizeInput(input, base);
+  if (inputsEqual(lastSent, next)) {
+    return;
+  }
+
+  const elapsed = Date.now() - lastSendAt;
+  if (elapsed >= THROTTLE_MS) {
+    flushPending(next);
+    return;
+  }
+
+  scheduleFlush(next);
+};

--- a/src/utils/livePresence.ts
+++ b/src/utils/livePresence.ts
@@ -1,0 +1,45 @@
+import type { LivePresence } from "../firebase";
+import type { ArenaPresenceEntry } from "../types/models";
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const readTimestamp = (value: unknown): string | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (!value || typeof value !== "object") return undefined;
+  const date = (value as { toDate?: () => Date }).toDate?.();
+  return date?.toISOString();
+};
+
+export const livePresenceToArenaEntry = (live: LivePresence): ArenaPresenceEntry => {
+  const raw = live as Record<string, unknown>;
+  const presenceId = normalizeString(live.presenceId) ?? normalizeString(raw.playerId) ?? live.id;
+  const playerId = normalizeString(raw.playerId) ?? presenceId;
+  const codename = normalizeString(raw.codename) ?? "Agent";
+  const displayName = normalizeString(raw.displayName);
+  const authUid = normalizeString(live.authUid) ?? presenceId;
+  const profileId = normalizeString(raw.profileId);
+  const joinedAt = readTimestamp(raw.joinedAt);
+  const lastSeen = typeof live.lastSeen === "number" ? new Date(live.lastSeen).toISOString() : readTimestamp(raw.lastSeen);
+  const expireAt = readTimestamp(raw.expireAt);
+
+  return {
+    presenceId,
+    playerId,
+    codename,
+    displayName,
+    joinedAt,
+    authUid,
+    profileId,
+    lastSeen,
+    expireAt,
+  };
+};
+
+export const mapLivePresenceToArenaEntries = (list: LivePresence[]): ArenaPresenceEntry[] =>
+  list.map(livePresenceToArenaEntry);

--- a/src/utils/useArenaRuntime.ts
+++ b/src/utils/useArenaRuntime.ts
@@ -4,7 +4,7 @@ import Phaser from "phaser";
 import { makeGame } from "../game/phaserGame";
 import ArenaScene, { type ArenaSceneConfig } from "../game/arena/ArenaScene";
 import { startHostLoop, type HostLoopController } from "../game/net/hostLoop";
-import { initActionBus, disposeActionBus } from "../net/ActionBus";
+import { initInputPublisher, disposeInputPublisher } from "../net/InputPublisher";
 import { createKeyBinder } from "../game/input/KeyBinder";
 import type { ArenaPresenceEntry } from "../types/models";
 import { writeArenaWriter } from "../firebase";
@@ -190,7 +190,7 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
       keyBinderRef.current = null;
     }
 
-    disposeActionBus();
+    disposeInputPublisher();
     setGameBooted(false);
   }, []);
 
@@ -230,7 +230,7 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
   // ActionBus lifecycle (session-scoped presenceId)
   useEffect(() => {
     if (!shouldBoot || !arenaId || !meUid || !myPresenceId) {
-      disposeActionBus();
+      disposeInputPublisher();
       return;
     }
 
@@ -239,7 +239,7 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
 
     (async () => {
       try {
-        await initActionBus({
+        await initInputPublisher({
           arenaId,
           presenceId: myPresenceId,
           codename: playerCodename,
@@ -253,7 +253,7 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
 
     return () => {
       cancelled = true;
-      disposeActionBus();
+      disposeInputPublisher();
     };
   }, [arenaId, codename, meUid, myPresenceId, shouldBoot]);
 


### PR DESCRIPTION
## Summary
- replace the ActionBus module with the new typed Firestore event writer
- add an input publisher helper and retarget game code to use it
- refresh presence watching logic to stream LivePresence docs and map them to arena entries

## Testing
- `npx tsc -p tsconfig.build.json --noEmit`
- `npm run build`
- `npx firebase-tools deploy --only hosting:stickfightpa` *(fails: npm registry access returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ed3a2ff8832ea63776174920da49