### PR TITLE
Remove stray debug block from writeArenaInput

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -913,8 +913,6 @@ export async function writeArenaInput(
     updatedAt: serverTimestamp(),
   };
 
-// assumes: ref: DocumentReference, input: any, payload: Record<string, unknown>
-{
   // stamp only known, correctly-typed fields
   if (typeof input.authUid === "string" && input.authUid.length > 0) {
     payload.authUid = input.authUid;


### PR DESCRIPTION
## Summary
- remove the stray debug comment and block wrapper around payload sanitation in writeArenaInput

## Testing
- npx tsc -p tsconfig.build.json --noEmit *(fails: unrelated missing exports in ActionBus)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f33b9070832ebff7ccbe10af70ab