### PR TITLE
Restore ActionBus scheduling and exports

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -913,8 +913,6 @@ export async function writeArenaInput(
     updatedAt: serverTimestamp(),
   };
 
-// assumes: ref: DocumentReference, input: any, payload: Record<string, unknown>
-{
   // stamp only known, correctly-typed fields
   if (typeof input.authUid === "string" && input.authUid.length > 0) {
     payload.authUid = input.authUid;


### PR DESCRIPTION
## Summary
- restore the action bus scheduler with throttle handling and re-export the lifecycle helpers so inputs can publish again
- ensure initialization, publish, reset, and dispose logic manage timers and Firestore cleanup
- clean up a truncated helper block in firebase input writer so TypeScript can parse the file

## Testing
- npx tsc -p tsconfig.build.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d0f33f4d18832ea6801e53e0eb2cce