### PR TITLE
Add debugging utilities and restore default text color

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,32 +6,6 @@
     <title>StickFight</title>
   </head>
   <body style="margin:0">
-    <!-- Canary: force all text red so deploys are obvious -->
-    <style>
-      html,
-      body,
-      #root {
-        color: #ff0000 !important;
-      }
-
-      * {
-        color: #ff0000 !important;
-      }
-    </style>
-    <div
-      style="
-        position: fixed;
-        bottom: 8px;
-        right: 8px;
-        z-index: 99999;
-        padding: 6px 8px;
-        border: 1px dashed #ff0000;
-        background: rgba(255, 0, 0, 0.07);
-        font-size: 10px;
-      "
-    >
-      RED CANARY ACTIVE
-    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,0 +1,62 @@
+declare global {
+  interface Window {
+    __PASf_DEBUG?: boolean;
+  }
+}
+
+function computeDebugEnabled(): boolean {
+  // Enable via query string ?debug=1 or localStorage.PASf_DEBUG="1"
+  try {
+    if (typeof window !== "undefined") {
+      if (/[?&]debug=1\b/.test(window.location.search)) return true;
+      if (window.localStorage?.getItem("PASf_DEBUG") === "1") return true;
+    }
+  } catch {}
+  // Fallback: allow Vite flag, default off in prod
+  try {
+    // @ts-ignore
+    if (import.meta.env?.VITE_DEBUG_LOGS === "true") return true;
+    // @ts-ignore
+    if (import.meta.env?.DEV) return true;
+  } catch {}
+  return false;
+}
+
+export function enableDebug(on = true) {
+  if (typeof window === "undefined") return;
+  window.__PASf_DEBUG = !!on;
+}
+
+export function dbg(tag: string, payload?: unknown) {
+  if (typeof window === "undefined") return;
+  if (window.__PASf_DEBUG) {
+    // Use info (visible by default even with default console settings)
+    // Avoid JSON stringify to preserve objects live in console
+    // eslint-disable-next-line no-console
+    console.info(`[DEBUG] ${tag}`, payload ?? "");
+  }
+}
+
+// One-time setup: global traps
+export function setupGlobalDebug() {
+  if (typeof window === "undefined") return;
+  if (window.__PASf_DEBUG === undefined) window.__PASf_DEBUG = computeDebugEnabled();
+
+  // Trap uncaught errors
+  window.addEventListener("error", (e) => {
+    // eslint-disable-next-line no-console
+    console.error("[ERR] window.error", {
+      message: e.message,
+      filename: e.filename,
+      lineno: e.lineno,
+      colno: e.colno,
+      error: e.error,
+    });
+  });
+
+  // Trap unhandled promise rejections
+  window.addEventListener("unhandledrejection", (e) => {
+    // eslint-disable-next-line no-console
+    console.error("[ERR] unhandledrejection", { reason: e.reason });
+  });
+}

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -7,6 +7,7 @@ import {
   Timestamp,
   type DocumentData,
 } from "firebase/firestore";
+import { dbg } from "./debug";
 
 const PRESENCE_STALE_MS = 20_000;  // lastSeen ≤ 20s
 const HEARTBEAT_MS = 10_000;
@@ -33,6 +34,7 @@ export function watchArenaPresence(arenaId: string, onChange: (live: LivePresenc
       .map(d => ({ id: d.id, ...(d.data() as any) }))
       .filter(p => (now - toMillis(p.lastSeen)) <= PRESENCE_STALE_MS) as LivePresence[];
     console.info("[PRESENCE] live", { live: live.length, all: snap.size });
+    dbg("presence:live", { arenaId, live: live.length, all: snap.size });
     onChange(live);
   });
 }
@@ -47,6 +49,7 @@ export function startPresenceHeartbeat(arenaId: string, presenceId: string, auth
       { merge: true },
     );
     console.info("[PRESENCE] beat", { presenceId });
+    dbg("presence:beat", { arenaId, presenceId });
   };
 
   let timer: ReturnType<typeof setInterval> | null = null;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,22 @@ import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
 import "./styles/base.css";
 import { ensureAuth } from "./firebaseAuth";
+import { setupGlobalDebug, dbg, enableDebug } from "./lib/debug";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {
   throw new Error("Missing #root element");
 }
 const root = createRoot(rootEl);
+
+// Initialize debug traps early
+setupGlobalDebug();
+
+// Optional: force-on in prod while investigating (remove later)
+// enableDebug(true);
+
+// First breadcrumb
+dbg("boot:start", { href: typeof window !== "undefined" ? window.location.href : "" });
 
 ensureAuth();
 

--- a/src/net/InputPublisher.ts
+++ b/src/net/InputPublisher.ts
@@ -1,5 +1,6 @@
 import { app, db } from "../firebase";
 import { writeArenaInput, type InputPayload } from "./ActionBus";
+import { dbg } from "../lib/debug";
 
 const THROTTLE_MS = 60;
 
@@ -82,6 +83,11 @@ const flushPending = (next: NormalizedInput) => {
     payload.codename = context.codename;
   }
 
+  dbg("input:enqueue", {
+    arenaId: context.arenaId,
+    presenceId: context.presenceId,
+    type: payload.type,
+  });
   void writeArenaInput(db, app, context.arenaId, context.presenceId, payload).catch((error) => {
     console.warn("[INPUT] enqueue failed", error);
   });

--- a/src/utils/useArenaRuntime.ts
+++ b/src/utils/useArenaRuntime.ts
@@ -10,6 +10,7 @@ import { createKeyBinder } from "../game/input/KeyBinder";
 import type { ArenaPresenceEntry } from "../types/models";
 import { db, writeArenaWriter } from "../firebase";
 import { startPresenceHeartbeat, watchArenaPresence, type LivePresence } from "../lib/presence";
+import { dbg } from "../lib/debug";
 
 const DEBUG = import.meta.env.DEV && import.meta.env.VITE_DEBUG_ARENA_PAGE === "true";
 const ONLINE_WINDOW_MS = 20_000;
@@ -434,6 +435,11 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
   const isWriter = Boolean(meUid && writerUid && writerUid === meUid);
 
   useEffect(() => {
+    if (!arenaId || !myPresenceId) return;
+    dbg("writer:election", { arenaId, me: myPresenceId, isWriter, live: livePresence.length });
+  }, [arenaId, isWriter, livePresence.length, myPresenceId]);
+
+  useEffect(() => {
     if (!shouldBoot || !arenaId || !meUid) {
       if (hostLoopRef.current) {
         hostLoopRef.current.stop();
@@ -507,6 +513,7 @@ export function useArenaRuntime(options: UseArenaRuntimeOptions): UseArenaRuntim
       if (data) {
         console.info("[STATE] snapshot", { ts: (data as { ts?: unknown }).ts });
       }
+      dbg("state:snapshot", { arenaId, hasData: !!data, ts: (data as { ts?: unknown })?.ts });
     });
   }, [arenaId]);
 


### PR DESCRIPTION
## Summary
- remove the temporary red canary styling from the HTML entrypoint
- add a reusable debug helper with global error traps and optional runtime toggles
- instrument presence, state, and input flows with dbg() breadcrumbs for higher-signal logging

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1816b28ec832e90f2f50fc4dedf75