### PR TITLE
Boot Phaser arena scene on ArenaPage

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -1,11 +1,146 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import Phaser from "phaser";
 import { useParams } from "react-router-dom";
-import { useArenaRuntime } from "../utils/useArenaRuntime";
+
+import { useAuth } from "../context/AuthContext";
+import { makeGame } from "../game/phaserGame";
+import ArenaScene, { type ArenaSceneConfig } from "../game/arena/ArenaScene";
 import DebugDock from "../components/DebugDock";
+import { useArenaRuntime } from "../utils/useArenaRuntime";
+
+const ARENA_WIDTH = 960;
+const ARENA_HEIGHT = 540;
+const ARENA_GROUND_HEIGHT = 40;
+const PLAYER_FLOOR_OFFSET = 60;
+const DEFAULT_SPAWN = {
+  x: 240,
+  y: ARENA_HEIGHT - ARENA_GROUND_HEIGHT - PLAYER_FLOOR_OFFSET,
+};
 
 export default function ArenaPage() {
   const params = useParams<{ id: string }>();
   const arenaId = (params.id ?? "CLIFF").toUpperCase();
-  const { live, stable, enqueueInput } = useArenaRuntime(arenaId);
+  const { user, player } = useAuth();
+  const { presenceId, live, stable, enqueueInput, bootError } = useArenaRuntime(arenaId);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const latestConfigRef = useRef<ArenaSceneConfig>();
+
+  const [sceneBooted, setSceneBooted] = useState(false);
+  const [gameBootError, setGameBootError] = useState<string | null>(null);
+
+  const codename = useMemo(() => {
+    if (player?.codename && player.codename.trim().length > 0) {
+      return player.codename.trim();
+    }
+    if (player?.displayName && player.displayName.trim().length > 0) {
+      return player.displayName.trim();
+    }
+    return "Agent";
+  }, [player?.codename, player?.displayName]);
+
+  const meAuthUid = user?.uid;
+  const meId = presenceId ?? meAuthUid ?? `local-${arenaId}`;
+
+  const sceneConfig = useMemo<ArenaSceneConfig>(
+    () => ({
+      arenaId,
+      me: { id: meId, codename, authUid: meAuthUid },
+      spawn: { ...DEFAULT_SPAWN },
+    }),
+    [arenaId, codename, meAuthUid, meId],
+  );
+
+  useEffect(() => {
+    latestConfigRef.current = sceneConfig;
+  }, [sceneConfig]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    let disposed = false;
+    setSceneBooted(false);
+    setGameBootError(null);
+
+    const config: Phaser.Types.Core.GameConfig = {
+      type: Phaser.AUTO,
+      width: ARENA_WIDTH,
+      height: ARENA_HEIGHT,
+      parent: container,
+      backgroundColor: "#0a0a0a",
+      physics: { default: "arcade", arcade: { gravity: { x: 0, y: 900 }, debug: false } },
+      scene: [],
+    };
+
+    try {
+      console.info("[ArenaPage] booting Phaser", { arenaId });
+      const game = makeGame(config);
+      gameRef.current = game;
+      const configPayload = latestConfigRef.current ?? sceneConfig;
+      game.scene.add("Arena", ArenaScene, true, configPayload);
+      if (!disposed) {
+        setSceneBooted(true);
+      }
+    } catch (err) {
+      console.error("[ArenaPage] failed to boot Phaser", err);
+      if (!disposed) {
+        setGameBootError(err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    return () => {
+      if (!disposed) {
+        setSceneBooted(false);
+        disposed = true;
+      }
+      const game = gameRef.current;
+      if (game) {
+        console.info("[ArenaPage] destroying Phaser");
+        game.destroy(true);
+        gameRef.current = null;
+      }
+    };
+  }, [arenaId]);
+
+  useEffect(() => {
+    if (!sceneBooted) {
+      return;
+    }
+    const game = gameRef.current;
+    if (!game) {
+      return;
+    }
+    const configPayload = latestConfigRef.current ?? sceneConfig;
+    const arenaScene = game.scene.getScene("Arena");
+    if (!arenaScene) {
+      return;
+    }
+    console.info("[ArenaPage] refreshing Arena scene", {
+      arenaId: configPayload.arenaId,
+      meId: configPayload.me.id,
+    });
+    arenaScene.scene.restart(configPayload);
+  }, [sceneBooted, sceneConfig]);
+
+  const overlayState = useMemo(() => {
+    if (gameBootError) {
+      return { tone: "error" as const, message: `Renderer offline: ${gameBootError}` };
+    }
+    if (bootError) {
+      return { tone: "error" as const, message: `Arena bootstrap failed: ${bootError}` };
+    }
+    if (!sceneBooted) {
+      return { tone: "info" as const, message: "Booting arena renderer…" };
+    }
+    if (!presenceId) {
+      return { tone: "info" as const, message: "Linking presence channel…" };
+    }
+    return null;
+  }, [bootError, gameBootError, presenceId, sceneBooted]);
 
   return (
     <>
@@ -13,14 +148,57 @@ export default function ArenaPage() {
         <h1>Arena {arenaId}</h1>
         <p>Players online: {live.length}</p>
         <p>{stable ? "Ready for combat" : "Waiting for rivals"}</p>
-        <button
-          type="button"
-          onClick={() => enqueueInput({ type: "move", dx: 1 })}
-        >
+        <p className="muted" style={{ fontFamily: "var(--font-mono)", fontSize: "0.85rem" }}>
+          Presence: {presenceId ?? "connecting"}
+        </p>
+        <button type="button" onClick={() => enqueueInput({ type: "move", dx: 1 })}>
           Move ➡️
         </button>
       </div>
+      <section className="card" style={{ marginTop: 24 }}>
+        <h2 style={{ marginBottom: 12 }}>Arena Feed</h2>
+        <div
+          className="canvas-frame"
+          style={{
+            position: "relative",
+            minHeight: ARENA_HEIGHT,
+            border: "1px solid var(--line)",
+            borderRadius: "var(--radius)",
+            background: "var(--bg-soft)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            ref={containerRef}
+            style={{ width: ARENA_WIDTH, height: ARENA_HEIGHT, margin: "0 auto" }}
+          />
+          {overlayState ? (
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "0 24px",
+                textAlign: "center",
+                color: overlayState.tone === "error" ? "#f87171" : "#bfdbfe",
+                backgroundColor:
+                  overlayState.tone === "error" ? "rgba(15, 17, 21, 0.84)" : "rgba(15, 17, 21, 0.6)",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.95rem",
+                letterSpacing: "0.04em",
+                pointerEvents: "none",
+              }}
+            >
+              {overlayState.message}
+            </div>
+          ) : null}
+        </div>
+        <div className="card-footer">[SIM] Phaser arena scene · multiplayer feed</div>
+      </section>
       <DebugDock />
     </>
   );
 }
+

--- a/src/utils/useArenaRuntime.tsx
+++ b/src/utils/useArenaRuntime.tsx
@@ -13,12 +13,15 @@ export function useArenaRuntime(arenaId: string, playerId?: string, profile?: { 
   const [presenceId, setPresenceId] = useState<string>();
   const [live, setLive] = useState<LivePresence[]>([]);
   const [stable, setStable] = useState(false);
+  const [bootError, setBootError] = useState<string | null>(null);
   const offRef = useRef<() => void>();
   const stopPresenceRef = useRef<() => Promise<void>>();
   const stopWriterRef = useRef<() => void>();
 
   useEffect(() => {
     let cancelled = false;
+    setBootError(null);
+    setPresenceId(undefined);
     (async () => {
       console.info("[ARENA] boot", { arenaId });
       try {
@@ -32,8 +35,12 @@ export function useArenaRuntime(arenaId: string, playerId?: string, profile?: { 
         }
         setPresenceId(myPresenceId);
         stopPresenceRef.current = stop;
+        setBootError(null);
       } catch (e: any) {
         console.error("[ARENA] boot-failed", { message: String(e?.message ?? e) });
+        if (!cancelled) {
+          setBootError(typeof e?.message === "string" ? e.message : String(e));
+        }
       }
     })();
     return () => {
@@ -101,5 +108,5 @@ export function useArenaRuntime(arenaId: string, playerId?: string, profile?: { 
     };
   }, [arenaId]);
 
-  return { presenceId, live, stable, enqueueInput };
+  return { presenceId, live, stable, enqueueInput, bootError };
 }


### PR DESCRIPTION
## Summary
- add a Phaser-backed canvas and overlay to the arena page so the ArenaScene boots immediately
- manage Phaser lifecycle on mount/unmount and restart when runtime identifiers change
- expose boot errors from useArenaRuntime so the UI can surface Firestore bootstrap failures

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1b0956ee4832ea8c87b998bde637f