### PR TITLE
Handle Firestore presence registration failures

### DIFF
--- a/src/arena/presence.ts
+++ b/src/arena/presence.ts
@@ -3,6 +3,7 @@ import { doc, setDoc, serverTimestamp } from "firebase/firestore";
 import { nanoid } from "nanoid";
 
 const HEARTBEAT_MS = 10000;
+const MAX_CONSECUTIVE_FAILURES = 3;
 
 export const startPresence = async (arenaId: string, playerId?: string, profile?: { displayName?: string }) => {
   const uid = auth.currentUser?.uid;
@@ -10,7 +11,18 @@ export const startPresence = async (arenaId: string, playerId?: string, profile?
   const presenceId = nanoid(10);
   const ref = doc(db, "arenas", arenaId, "presence", presenceId);
 
-  const write = async (stage: "start"|"beat") => {
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let consecutiveFailures = 0;
+  let stopped = false;
+
+  const clearTimer = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+  };
+
+  const write = async (stage: "start" | "beat") => {
     try {
       await setDoc(ref, {
         authUid: uid,
@@ -20,18 +32,32 @@ export const startPresence = async (arenaId: string, playerId?: string, profile?
         lastSeenSrv: serverTimestamp(),
         stage,
       }, { merge: true });
+      consecutiveFailures = 0;
       if (stage === "start") console.info("[PRESENCE] started", { arenaId, presenceId, uid });
       else console.info("[PRESENCE] beat", { presenceId });
     } catch (e: any) {
-      console.error("[PRESENCE] write-failed", { code: e?.code, message: e?.message });
+      consecutiveFailures += 1;
+      console.error("[PRESENCE] write-failed", { stage, code: e?.code, message: e?.message });
+      if (stage === "start") {
+        clearTimer();
+        throw e instanceof Error ? e : new Error(String(e ?? "presence-start-failed"));
+      }
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        console.error("[PRESENCE] heartbeat-stopped", { presenceId, failures: consecutiveFailures });
+        clearTimer();
+      }
     }
   };
 
   await write("start");
-  const timer = setInterval(() => write("beat"), HEARTBEAT_MS);
+  timer = setInterval(() => {
+    void write("beat");
+  }, HEARTBEAT_MS);
 
   const stop = async () => {
-    clearInterval(timer);
+    if (stopped) return;
+    stopped = true;
+    clearTimer();
     try { await setDoc(ref, { lastSeen: Date.now(), lastSeenSrv: serverTimestamp(), stage: "stop" }, { merge: true }); }
     catch (e: any) { console.error("[PRESENCE] stop-failed", { code: e?.code, message: e?.message }); }
   };

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -5,7 +5,7 @@ import DebugDock from "../components/DebugDock";
 export default function ArenaPage() {
   const params = useParams<{ id: string }>();
   const arenaId = (params.id ?? "CLIFF").toUpperCase();
-  const { live, stable, enqueueInput } = useArenaRuntime(arenaId);
+  const { live, stable, enqueueInput, bootError, nextRetryAt } = useArenaRuntime(arenaId);
 
   return (
     <>
@@ -13,6 +13,16 @@ export default function ArenaPage() {
         <h1>Arena {arenaId}</h1>
         <p>Players online: {live.length}</p>
         <p>{stable ? "Ready for combat" : "Waiting for rivals"}</p>
+        {bootError && (
+          <p className="text-red-400">
+            Presence setup failed: {bootError}
+            {nextRetryAt && (
+              <>
+                {" "}(retrying at {new Date(nextRetryAt).toLocaleTimeString()})
+              </>
+            )}
+          </p>
+        )}
         <button
           type="button"
           onClick={() => enqueueInput({ type: "move", dx: 1 })}


### PR DESCRIPTION
## Summary
- rethrow initial Firestore write failures when starting presence and stop the heartbeat after repeated errors
- add retry/backoff handling in `useArenaRuntime` to surface errors and keep the runtime in a safe state
- display retry messaging on the arena page when presence setup fails

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1b0984d20832e9a5f851e3e0d0a8d