### PR TITLE
Allow presence creates and soften permission overlay

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,21 +16,24 @@ service cloud.firestore {
       // Session-scoped presence (per-tab)
       match /presence/{presenceId} {
         allow read: if true;
-        // TEMP: allow any authed client to create/update/delete its presence doc.
-        // After we confirm, we can tighten to require authUid match.
-        allow create, update, delete: if authed();
-        // Tighter version for later:
-        // allow create, update, delete: if authed() &&
-        //   request.resource.data.authUid == request.auth.uid;
+
+        // Create: allow any authed client to create its presence doc when it stamps its UID
+        allow create: if authed()
+          && request.resource.data.authUid == request.auth.uid;
+
+        // Update/Delete: only the owner of the existing doc may change/remove it;
+        // prevent authUid from being hijacked.
+        allow update, delete: if authed()
+          && resource.data.authUid == request.auth.uid
+          && (!('authUid' in request.resource.data)
+              || request.resource.data.authUid == resource.data.authUid);
       }
 
       // Inputs fan-in: inputs/{presenceId}/events/{eventId}
       match /inputs/{presenceId}/events/{eventId} {
         allow read: if true;
-        allow create: if authed();
-        // Tighter later:
-        // allow create: if authed() &&
-        //   request.resource.data.authUid == request.auth.uid;
+        allow create: if authed()
+          && request.resource.data.authUid == request.auth.uid;
       }
     }
 

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -114,8 +114,6 @@ export default function ArenaPage() {
     arenaScene.scene.restart(payload);
   }, [sceneBooted, sceneConfig]);
 
-  const permDenied = bootError?.toLowerCase?.().includes("permission") ?? false;
-
   // Non-blocking overlay to surface boot/runtime status
   const overlayState = useMemo(() => {
     if (gameBootError) return { tone: "error" as const, message: `Renderer offline: ${gameBootError}` };
@@ -124,6 +122,8 @@ export default function ArenaPage() {
     if (!presenceId) return { tone: "info" as const, message: "Linking presence channel…" };
     return null;
   }, [bootError, gameBootError, presenceId, sceneBooted]);
+
+  const permDenied = (bootError ?? "").toLowerCase().includes("permission");
 
   return (
     <>
@@ -151,11 +151,11 @@ export default function ArenaPage() {
               fontSize: "0.85rem",
               color: "#f87171",
               border: "1px solid rgba(248,113,113,0.35)",
-              borderRadius: "8px",
+              borderRadius: 8,
               background: "rgba(15,17,21,0.6)",
             }}
           >
-            Arena bootstrap failed (permissions). Gameplay may be local-only.
+            Arena bootstrap failed (permissions). Gameplay may be local-only until rules are fixed.
           </div>
         )}
         <div
@@ -189,7 +189,7 @@ export default function ArenaPage() {
                 pointerEvents: "none",
               }}
             >
-            {overlayState.message}
+              {overlayState.message}
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- tighten presence creation rules while allowing authenticated clients to create their own docs
- keep update/delete ownership guarantees and require auth for inputs fan-in
- show a slim permission warning banner without blocking the arena canvas

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1c58fcd30832ea836e114d45c1d83