### PR TITLE
Initialize Firebase App Check on web client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Choose: "enterprise" or "v3"
+VITE_APPCHECK_PROVIDER=v3
+# Your reCAPTCHA (Enterprise or v3) SITE key — not the secret
+VITE_APPCHECK_SITE_KEY=YOUR_RECAPTCHA_SITE_KEY

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "./firebase";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";

--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -155,7 +155,7 @@ export default function ArenaPage() {
               background: "rgba(15,17,21,0.6)",
             }}
           >
-            Arena bootstrap failed (permissions). Gameplay may be local-only until rules are fixed.
+            Arena bootstrap failed (permissions). Gameplay may be local-only until rules/App Check are enforced.
           </div>
         )}
         <div


### PR DESCRIPTION
## Summary
- initialize Firebase App Check immediately after creating the Firebase app and before exporting service instances, including dev debug token support and provider selection
- add a side-effect import of the Firebase module in the main entry point so App Check runs before other Firebase consumers
- document the required App Check environment variables and polish the arena permission banner copy

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1ce09d824832e906cbba6b22a4ba6