### PR TITLE
Improve presence logging and clear boot banner

### DIFF
--- a/src/utils/useArenaRuntime.tsx
+++ b/src/utils/useArenaRuntime.tsx
@@ -77,6 +77,7 @@ export function useArenaRuntime(
           return;
         }
         setPresenceId(myPresenceId);
+        setBootError(null);
         stopPresenceRef.current = stop;
         console.info("[PRESENCE] started", { arenaId, presenceId: myPresenceId });
 


### PR DESCRIPTION
## Summary
- add probe and detailed logging when starting or beating presence to surface auth mismatches
- ensure heartbeat payload includes required fields and capture probe outcomes
- clear bootstrap permission banner as soon as presence successfully starts

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1d9259fa4832ea6cb5cbd93f7c032