### PR TITLE
Reset anon auth ready on failure

### DIFF
--- a/src/auth/ensureAnonAuth.ts
+++ b/src/auth/ensureAnonAuth.ts
@@ -4,12 +4,30 @@ import { auth } from "../firebase";
 let ready: Promise<string> | null = null;
 export const ensureAnonAuth = (): Promise<string> => {
   if (ready) return ready;
-  ready = new Promise((resolve, reject) => {
+  const promise = new Promise<string>((resolve, reject) => {
     const off = onAuthStateChanged(auth, async (u) => {
-      if (u) { off(); console.info("[ARENA] auth", { uid: u.uid }); resolve(u.uid); return; }
-      try { const cred = await signInAnonymously(auth); off(); console.info("[ARENA] auth", { uid: cred.user.uid }); resolve(cred.user.uid); }
-      catch (e) { console.error("[ARENA] auth-failed", e); reject(e); }
+      if (u) {
+        off();
+        console.info("[ARENA] auth", { uid: u.uid });
+        resolve(u.uid);
+        return;
+      }
+      try {
+        const cred = await signInAnonymously(auth);
+        off();
+        console.info("[ARENA] auth", { uid: cred.user.uid });
+        resolve(cred.user.uid);
+      } catch (e) {
+        off();
+        ready = null;
+        console.error("[ARENA] auth-failed", e);
+        reject(e);
+      }
     });
+  });
+  ready = promise.catch((error) => {
+    ready = null;
+    throw error;
   });
   return ready;
 };


### PR DESCRIPTION
## Summary
- call `off()` before logging anonymous auth failures
- reset the `ready` promise when anonymous sign-in fails so retries are possible
- ensure other promise rejections also clear `ready`

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1df07a25c832ea1fdf3d8c85c470c