### PR TITLE
Log Firebase project on startup

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,4 +1,4 @@
-import { initializeApp } from "firebase/app";
+import { getApp, initializeApp } from "firebase/app";
 import {
   initializeAppCheck,
   ReCaptchaEnterpriseProvider,
@@ -47,6 +47,7 @@ export const firebaseConfig = {
 
 // === SINGLETONS ===
 export const app = initializeApp(firebaseConfig);
+console.info("[ARENA] firebase-project", { projectId: getApp().options.projectId });
 
 // --- App Check (must execute BEFORE any db/auth/functions usage) ---
 (() => {


### PR DESCRIPTION
## Summary
- import `getApp` alongside `initializeApp`
- log the Firebase project ID immediately after initializing the app so it always runs on startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1df0e2380832eb344337d6b395b8e