### PR TITLE
Improve presence probing and auth resilience

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -26,7 +26,7 @@ export default function ArenaPage() {
   const { user, player } = useAuth();
 
   // Runtime hook provides presence + inputs (and any boot error upstream)
-  const { presenceId, live, stable, enqueueInput, bootError } = useArenaRuntime(arenaId);
+  const { presenceId, live, stable, enqueueInput, bootError, lastBootErrorAt } = useArenaRuntime(arenaId);
 
   // Phaser mounts regardless of Firestore success/failure
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -124,6 +124,10 @@ export default function ArenaPage() {
   }, [bootError, gameBootError, presenceId, sceneBooted]);
 
   const permDenied = (bootError ?? "").toLowerCase().includes("permission");
+  const showPermBanner =
+    permDenied &&
+    !presenceId &&
+    (!lastBootErrorAt || Date.now() - lastBootErrorAt < 20000);
 
   return (
     <>
@@ -141,7 +145,7 @@ export default function ArenaPage() {
 
       <section className="card" style={{ marginTop: 24 }}>
         <h2 style={{ marginBottom: 12 }}>Arena Feed</h2>
-        {permDenied && (
+        {showPermBanner && (
           <div
             role="status"
             className="my-3"
@@ -170,7 +174,7 @@ export default function ArenaPage() {
           }}
         >
           <div ref={containerRef} style={{ width: ARENA_WIDTH, height: ARENA_HEIGHT, margin: "0 auto" }} />
-          {!permDenied && overlayState ? (
+          {!showPermBanner && overlayState ? (
             <div
               style={{
                 position: "absolute",


### PR DESCRIPTION
## Summary
- change the presence probe to merge into the arena root doc and preserve detailed logging
- harden anonymous auth bootstrapping with retryable inflight handling and early project logging
- clear stale permission errors once presence succeeds and only surface the banner for recent failures

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1e33392e4832e9006110184ee866b