### PR TITLE
Unify arena input transport

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,16 +35,15 @@ service cloud.firestore {
         allow update, delete: if isOwnerUpdate();
       }
 
-      // Inputs fan-in: inputs/{presenceId}/events/{eventId}
+      // Inputs fan-in: inputs/{presenceId}
       match /inputs/{presenceId} {
         allow read: if true;
 
-        match /events/{eventId} {
-          allow read: if true;
-          allow create: if authed()
-            && request.resource.data.authUid == request.auth.uid
-            && request.resource.data.presenceId == presenceId;
-        }
+        allow create: if isOwnerCreate() && request.resource.data.presenceId == presenceId;
+        allow update: if isOwnerUpdate()
+          && resource.data.presenceId == presenceId
+          && (!('presenceId' in request.resource.data) || request.resource.data.presenceId == presenceId);
+        allow delete: if isOwnerUpdate() && resource.data.presenceId == presenceId;
       }
     }
 

--- a/src/net/ActionBus.ts
+++ b/src/net/ActionBus.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection, doc } from "firebase/firestore";
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
 import { auth, db } from "../firebase";
 
 export type InputPayload = { type: string; [k: string]: unknown };
@@ -9,7 +9,24 @@ export const writeArenaInput = async (arenaId: string, presenceId: string, paylo
     console.info("[INPUT] rejected", { presenceId, reason: "no-auth" });
     return;
   }
-  const ref = collection(doc(db, "arenas", arenaId), "inputs", presenceId, "events");
-  await addDoc(ref, { ...payload, authUid, presenceId, createdAt: Date.now() });
+  const ref = doc(db, "arenas", arenaId, "inputs", presenceId);
+  const now = serverTimestamp();
+  const data: Record<string, unknown> = {
+    authUid,
+    playerId: presenceId,
+    presenceId,
+    updatedAt: now,
+  };
+
+  if (typeof payload.left === "boolean") data.left = payload.left;
+  if (typeof payload.right === "boolean") data.right = payload.right;
+  if (typeof payload.jump === "boolean") data.jump = payload.jump;
+  if (typeof payload.attack === "boolean") data.attack = payload.attack;
+  if (typeof payload.attackSeq === "number") data.attackSeq = payload.attackSeq;
+  if (typeof payload.codename === "string" && payload.codename.length > 0) {
+    data.codename = payload.codename;
+  }
+
+  await setDoc(ref, data, { merge: true });
   console.info("[INPUT] enqueued", { presenceId, type: payload?.type });
 };


### PR DESCRIPTION
## Summary
- update ActionBus to merge arena inputs into arenas/{arenaId}/inputs/{presenceId}
- refresh Firestore rules to authorize per-presence input documents

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f0d1f388832ea5931d577714b6cb