### PR TITLE
Fix presence rules and client handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ After loading the app locally, you can confirm Firebase connectivity by pasting 
 ```
 
 It signs in anonymously (if needed) and fetches the arenas collection, logging the results.
+
+## Firestore Rules Playground
+
+The repository includes a ready-to-run Rules Playground request at `docs/rules-playground.json`. To validate the presence rules:
+
+1. Open the Firebase Console → Firestore → Rules.
+2. Click **Rules Playground**.
+3. Paste the contents of `docs/rules-playground.json` into the request editor.
+4. Run the simulation and confirm it returns **ALLOW**.
+
+This payload exercises the `/arenas/CLIFF/presence/testPresence` create path with the expected `authUid`, timestamps, and heartbeat fields.

--- a/docs/rules-playground.json
+++ b/docs/rules-playground.json
@@ -1,0 +1,18 @@
+{
+  "path": "/databases/(default)/documents/arenas/CLIFF/presence/testPresence",
+  "method": "create",
+  "request": {
+    "auth": { "uid": "a5SrzfmvsicZNlSDpczqAUVX52Y2" },
+    "resource": {
+      "data": {
+        "authUid": "a5SrzfmvsicZNlSDpczqAUVX52Y2",
+        "presenceId": "testPresence",
+        "displayName": "Player Y2",
+        "stage": "start",
+        "lastSeen": "REQUEST_TIME",
+        "lastSeenSrv": "REQUEST_TIME",
+        "heartbeatMs": 10000
+      }
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,24 +26,20 @@ service cloud.firestore {
         allow write: if authed();
       }
 
-      // Session-scoped presence (per-tab)
       match /presence/{presenceId} {
-        // On CREATE, resource does not exist; use request.resource.data.*
-        // On UPDATE, resource.data exists; keep authUid immutable.
         allow read: if true;
         allow create: if isOwnerCreate();
         allow update, delete: if isOwnerUpdate();
       }
 
-      // Inputs fan-in: inputs/{presenceId}
       match /inputs/{presenceId} {
         allow read: if true;
-
-        allow create: if isOwnerCreate() && request.resource.data.presenceId == presenceId;
-        allow update: if isOwnerUpdate()
-          && resource.data.presenceId == presenceId
-          && (!('presenceId' in request.resource.data) || request.resource.data.presenceId == presenceId);
-        allow delete: if isOwnerUpdate() && resource.data.presenceId == presenceId;
+        match /events/{eventId} {
+          allow read: if true;
+          allow create: if authed()
+            && request.resource.data.authUid == request.auth.uid
+            && request.resource.data.presenceId == presenceId;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- replace arena presence and input Firestore rules with the minimal owner-based policy
- create the presence document with a clean write, then send heartbeat updates from the client
- simplify the presence watcher, add a Rules Playground vector, and document the console test steps

## Testing
- npm run typecheck
- npm run test:build

------
https://chatgpt.com/codex/tasks/task_e_68d1fb9b0a60832ebbc05677b40c4467