### PR TITLE
Handle non-fatal arena probes and clear bootstrap overlay

### DIFF
--- a/src/auth/ensureAnonAuth.ts
+++ b/src/auth/ensureAnonAuth.ts
@@ -4,6 +4,12 @@ import { auth } from "../firebase";
 
 let inflight: Promise<string> | null = null;
 
+const RETRYABLE_AUTH_ERRORS = new Set([
+  "auth/internal-error",
+  "auth/network-request-failed",
+  "auth/too-many-requests",
+]);
+
 export async function ensureAnonAuth(retryMs = 0): Promise<string> {
   if (inflight) return inflight;
   console.info("[ARENA] firebase-project", { projectId: getApp().options.projectId });
@@ -36,8 +42,16 @@ export async function ensureAnonAuth(retryMs = 0): Promise<string> {
       });
       console.info("[ARENA] auth", { uid });
       return uid;
-    } catch (e) {
+    } catch (e: any) {
       inflight = null;
+      const code = e?.code ?? e?.name;
+      const message = String(e?.message ?? e);
+      if (RETRYABLE_AUTH_ERRORS.has(code)) {
+        const delay = Math.floor(250 + Math.random() * 750);
+        console.warn("[AUTH] ensureAnonAuth retry", { code, delay, message });
+        await new Promise((r) => setTimeout(r, delay));
+        return ensureAnonAuth(0);
+      }
       if (retryMs > 0) {
         await new Promise((r) => setTimeout(r, retryMs));
         return ensureAnonAuth(0);


### PR DESCRIPTION
## Summary
- touch the arena root and safe bootstrap probe while treating permission-denied errors as non-fatal
- boot the arena runtime with auth → seeding → presence and surface non-fatal probe warnings without blocking the overlay
- add a lightweight auth retry backoff and inline probe banner once connected

## Testing
- npm run typecheck
- npm run test:build

------
https://chatgpt.com/codex/tasks/task_e_68d2001959b8832e947f28630510742c