### PR TITLE
Add admin delete cloud functions and console controls

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,6 +19,7 @@ service cloud.firestore {
     match /arenas/{arenaId} {
       allow read: if true;
       allow create, update: if authed(); // arena metadata
+      allow delete: if request.auth != null && request.auth.token.admin == true;
 
       // Host-authoritative state (writer elected in app)
       match /state/{docId} {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "stickfight-functions",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "18"
+  },
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.11.1",
+    "firebase-functions": "^4.8.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/functions/src/adminDelete.ts
+++ b/functions/src/adminDelete.ts
@@ -1,0 +1,142 @@
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+const { HttpsError } = functions.https;
+
+type CallableContext = functions.https.CallableContext;
+
+type DeleteByQueryOptions = {
+  limit?: number;
+};
+
+async function deleteByQuery(
+  query: FirebaseFirestore.Query<FirebaseFirestore.DocumentData>,
+  options: DeleteByQueryOptions = {},
+): Promise<number> {
+  const batchSize = Math.max(1, Math.min(options.limit ?? 250, 500));
+  let totalDeleted = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const snapshot = await query.limit(batchSize).get();
+    if (snapshot.empty) {
+      break;
+    }
+
+    const batch = db.batch();
+    snapshot.docs.forEach((doc) => {
+      batch.delete(doc.ref);
+    });
+    await batch.commit();
+
+    totalDeleted += snapshot.size;
+
+    if (snapshot.size < batchSize) {
+      break;
+    }
+  }
+
+  return totalDeleted;
+}
+
+function assertAdmin(context: CallableContext): asserts context is CallableContext & {
+  auth: NonNullable<CallableContext["auth"]> & {
+    token: NonNullable<CallableContext["auth"]>["token"] & { admin?: boolean };
+  };
+} {
+  const isAdmin = Boolean(context.auth?.token && (context.auth.token as { admin?: boolean }).admin === true);
+  if (!isAdmin) {
+    throw new HttpsError("permission-denied", "Admin privileges required");
+  }
+}
+
+function sanitizeId(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new HttpsError("invalid-argument", `${field} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new HttpsError("invalid-argument", `${field} cannot be empty`);
+  }
+
+  return trimmed;
+}
+
+export interface AdminDeleteArenaResponse {
+  ok: true;
+  arenaId: string;
+}
+
+export interface AdminDeletePlayerResponse {
+  ok: true;
+  playerId: string;
+  purgeRelated: boolean;
+}
+
+export const adminDeleteArena = functions
+  .region("us-central1")
+  .https.onCall(async (data, context): Promise<AdminDeleteArenaResponse> => {
+    assertAdmin(context);
+
+    const arenaId = sanitizeId(data?.arenaId, "arenaId");
+    const arenaRef = db.collection("arenas").doc(arenaId);
+
+    const subcollections = ["presence", "seats", "inputs", "state"] as const;
+
+    for (const sub of subcollections) {
+      await deleteByQuery(arenaRef.collection(sub));
+    }
+
+    await arenaRef.delete().catch((error) => {
+      if ((error as { code?: number }).code === 5) {
+        // Firestore NOT_FOUND; ignore for idempotency
+        return;
+      }
+      throw error;
+    });
+
+    functions.logger.info("adminDeleteArena", { arenaId });
+
+    return { ok: true, arenaId };
+  });
+
+export const adminDeletePlayer = functions
+  .region("us-central1")
+  .https.onCall(async (data, context): Promise<AdminDeletePlayerResponse> => {
+    assertAdmin(context);
+
+    const playerId = sanitizeId(data?.playerId, "playerId");
+    const purgeRelated = data?.purgeRelated !== false;
+
+    await db.collection("players").doc(playerId).delete().catch((error) => {
+      if ((error as { code?: number }).code === 5) {
+        return;
+      }
+      throw error;
+    });
+
+    if (purgeRelated) {
+      await deleteByQuery(
+        db
+          .collectionGroup("seats")
+          .where("uid", "==", playerId),
+      );
+      await deleteByQuery(
+        db
+          .collectionGroup("presence")
+          .where("authUid", "==", playerId),
+      );
+    }
+
+    functions.logger.info("adminDeletePlayer", { playerId, purgeRelated });
+
+    return { ok: true, playerId, purgeRelated };
+  });
+

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,1 @@
+export { adminDeleteArena, adminDeletePlayer } from "./adminDelete";

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "outDir": "lib",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,33 @@
+import { httpsCallable, getFunctions } from "firebase/functions";
+import { app } from "../firebase";
+
+export interface AdminDeleteArenaResponse {
+  ok: true;
+  arenaId: string;
+}
+
+export interface AdminDeletePlayerResponse {
+  ok: true;
+  playerId: string;
+  purgeRelated: boolean;
+}
+
+const functions = getFunctions(app, "us-central1");
+
+export async function callAdminDeleteArena(arenaId: string): Promise<AdminDeleteArenaResponse> {
+  const callable = httpsCallable<{ arenaId: string }, AdminDeleteArenaResponse>(functions, "adminDeleteArena");
+  const result = await callable({ arenaId });
+  return result.data;
+}
+
+export async function callAdminDeletePlayer(
+  playerId: string,
+  purgeRelated = true,
+): Promise<AdminDeletePlayerResponse> {
+  const callable = httpsCallable<
+    { playerId: string; purgeRelated: boolean },
+    AdminDeletePlayerResponse
+  >(functions, "adminDeletePlayer");
+  const result = await callable({ playerId, purgeRelated });
+  return result.data;
+}

--- a/src/components/AdminControls.tsx
+++ b/src/components/AdminControls.tsx
@@ -1,0 +1,179 @@
+import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import { getIdTokenResult, onIdTokenChanged } from "firebase/auth";
+
+import { auth } from "../firebase";
+import { callAdminDeleteArena, callAdminDeletePlayer } from "../api/admin";
+
+interface StatusMessage {
+  tone: "info" | "success" | "error";
+  message: string;
+}
+
+const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error) return error;
+  return "Unknown error";
+};
+
+const AdminControls: React.FC = () => {
+  const [checkingAdmin, setCheckingAdmin] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [arenaId, setArenaId] = useState("");
+  const [playerId, setPlayerId] = useState("");
+  const [purgeRelated, setPurgeRelated] = useState(true);
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onIdTokenChanged(auth, async (user) => {
+      if (!user) {
+        setIsAdmin(false);
+        setCheckingAdmin(false);
+        return;
+      }
+
+      try {
+        const result = await getIdTokenResult(user, true);
+        setIsAdmin(result.claims?.admin === true);
+      } catch (error) {
+        console.error("admin-check failed", error);
+        setIsAdmin(false);
+        setStatus({ tone: "error", message: `Failed to verify admin status: ${extractErrorMessage(error)}` });
+      } finally {
+        setCheckingAdmin(false);
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const handleDeleteArena = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = arenaId.trim();
+    if (!trimmed) {
+      setStatus({ tone: "error", message: "Arena ID is required." });
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Delete arena ${trimmed}? This removes the arena document and all related subcollections.`,
+    );
+    if (!confirmed) return;
+
+    setBusy(true);
+    setStatus({ tone: "info", message: `Deleting arena ${trimmed}…` });
+    try {
+      const result = await callAdminDeleteArena(trimmed);
+      setStatus({ tone: "success", message: `Arena ${result.arenaId} deleted.` });
+      setArenaId("");
+    } catch (error) {
+      console.error("delete-arena failed", error);
+      setStatus({ tone: "error", message: `Failed to delete arena: ${extractErrorMessage(error)}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDeletePlayer = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = playerId.trim();
+    if (!trimmed) {
+      setStatus({ tone: "error", message: "Player ID is required." });
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Delete player ${trimmed}? This removes the player document${
+        purgeRelated ? " and related presence/seats" : ""
+      } across arenas.`,
+    );
+    if (!confirmed) return;
+
+    setBusy(true);
+    setStatus({ tone: "info", message: `Deleting player ${trimmed}…` });
+    try {
+      const result = await callAdminDeletePlayer(trimmed, purgeRelated);
+      setStatus({
+        tone: "success",
+        message: `Player ${result.playerId} deleted${
+          result.purgeRelated ? " with related documents purged." : "."
+        }`,
+      });
+      setPlayerId("");
+    } catch (error) {
+      console.error("delete-player failed", error);
+      setStatus({ tone: "error", message: `Failed to delete player: ${extractErrorMessage(error)}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const statusMessage = useMemo(() => {
+    if (status) return status.message;
+    return "Ready.";
+  }, [status]);
+
+  const statusTone = status?.tone ?? "info";
+  const statusClass = `status-bar${statusTone === "error" ? " error" : ""}`;
+
+  if (checkingAdmin || !isAdmin) {
+    return null;
+  }
+
+  return (
+    <section className="card">
+      <div className="card-header">
+        <h2>Admin Controls</h2>
+        <span className="muted">Danger zone</span>
+      </div>
+
+      <div className={statusClass} role="status" aria-live="polite">
+        {statusMessage}
+      </div>
+
+      <div className="grid" style={{ gap: 16 }}>
+        <form onSubmit={handleDeleteArena}>
+          <fieldset disabled={busy} className="fieldset">
+            <label htmlFor="admin-arena-id">Arena ID</label>
+            <input
+              id="admin-arena-id"
+              value={arenaId}
+              onChange={(event) => setArenaId(event.target.value)}
+              placeholder="ARENA-ID"
+            />
+            <button className="button danger" type="submit">
+              Delete Arena
+            </button>
+          </fieldset>
+        </form>
+
+        <form onSubmit={handleDeletePlayer}>
+          <fieldset disabled={busy} className="fieldset">
+            <label htmlFor="admin-player-id">Player ID</label>
+            <input
+              id="admin-player-id"
+              value={playerId}
+              onChange={(event) => setPlayerId(event.target.value)}
+              placeholder="PLAYER-UID"
+            />
+
+            <label className="checkbox">
+              <input
+                type="checkbox"
+                checked={purgeRelated}
+                onChange={(event) => setPurgeRelated(event.target.checked)}
+              />
+              Purge seats/presence across arenas
+            </label>
+
+            <button className="button danger" type="submit">
+              Delete Player
+            </button>
+          </fieldset>
+        </form>
+      </div>
+    </section>
+  );
+};
+
+export default AdminControls;

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -10,6 +10,7 @@ import {
 import type { PlayerProfile } from "../types/models";
 import { useArenas } from "../utils/useArenas";
 import { useAuth } from "../context/AuthContext";
+import AdminControls from "../components/AdminControls";
 import DebugDock from "../components/DebugDock";
 
 const extractErrorMessage = (error: unknown) => {
@@ -143,181 +144,183 @@ const AdminPage = () => {
           {statusMessage}
         </div>
 
-      <div className="grid grid-2" style={{ alignItems: "start", gap: 24 }}>
-        <div className="grid" style={{ gap: 24 }}>
-          <section className="card">
-            <div className="card-header">
-              <h2>Boss Profile</h2>
-              <span className="muted">Identity</span>
-            </div>
-            <form onSubmit={handleEnsureBossProfile}>
-              <fieldset disabled={formsDisabled} className="fieldset">
-                <label htmlFor="boss-name">Display name</label>
-                <input
-                  id="boss-name"
-                  value={bossName}
-                  onChange={(e) => setBossName(e.target.value)}
-                  required
-                />
-                <button className="button" type="submit">
-                  Save Boss Profile
-                </button>
-              </fieldset>
-            </form>
-          </section>
+        <AdminControls />
 
-          <section className="card">
-            <div className="card-header">
-              <h2>Add Player</h2>
-              <span className="muted">Credentials</span>
-            </div>
-            <form onSubmit={handleCreatePlayer}>
-              <fieldset disabled={formsDisabled} className="fieldset">
-                <label htmlFor="player-codename">Codename</label>
-                <input
-                  id="player-codename"
-                  value={playerCodename}
-                  onChange={(e) => setPlayerCodename(e.target.value)}
-                  placeholder="e.g. midnight-spark"
-                  required
-                />
+        <div className="grid grid-2" style={{ alignItems: "start", gap: 24 }}>
+          <div className="grid" style={{ gap: 24 }}>
+            <section className="card">
+              <div className="card-header">
+                <h2>Boss Profile</h2>
+                <span className="muted">Identity</span>
+              </div>
+              <form onSubmit={handleEnsureBossProfile}>
+                <fieldset disabled={formsDisabled} className="fieldset">
+                  <label htmlFor="boss-name">Display name</label>
+                  <input
+                    id="boss-name"
+                    value={bossName}
+                    onChange={(e) => setBossName(e.target.value)}
+                    required
+                  />
+                  <button className="button" type="submit">
+                    Save Boss Profile
+                  </button>
+                </fieldset>
+              </form>
+            </section>
 
-                <label htmlFor="player-passcode">Passcode (share privately)</label>
-                <input
-                  id="player-passcode"
-                  value={playerPasscode}
-                  onChange={(e) => setPlayerPasscode(e.target.value)}
-                  placeholder="auto-generated or custom"
-                  required
-                />
+            <section className="card">
+              <div className="card-header">
+                <h2>Add Player</h2>
+                <span className="muted">Credentials</span>
+              </div>
+              <form onSubmit={handleCreatePlayer}>
+                <fieldset disabled={formsDisabled} className="fieldset">
+                  <label htmlFor="player-codename">Codename</label>
+                  <input
+                    id="player-codename"
+                    value={playerCodename}
+                    onChange={(e) => setPlayerCodename(e.target.value)}
+                    placeholder="e.g. midnight-spark"
+                    required
+                  />
 
-                <button className="button" type="submit">
-                  Create Player
-                </button>
-              </fieldset>
-            </form>
-          </section>
+                  <label htmlFor="player-passcode">Passcode (share privately)</label>
+                  <input
+                    id="player-passcode"
+                    value={playerPasscode}
+                    onChange={(e) => setPlayerPasscode(e.target.value)}
+                    placeholder="auto-generated or custom"
+                    required
+                  />
 
-          <section className="card">
-            <div className="card-header">
-              <h2>Add Arena</h2>
-              <span className="muted">Deploy</span>
-            </div>
-            <form onSubmit={handleCreateArena}>
-              <fieldset disabled={formsDisabled} className="fieldset">
-                <label htmlFor="arena-name">Name</label>
-                <input
-                  id="arena-name"
-                  value={arenaName}
-                  onChange={(e) => setArenaName(e.target.value)}
-                  placeholder="e.g. Forge Alpha"
-                  required
-                />
+                  <button className="button" type="submit">
+                    Create Player
+                  </button>
+                </fieldset>
+              </form>
+            </section>
 
-                <label htmlFor="arena-description">Description</label>
-                <input
-                  id="arena-description"
-                  value={arenaDescription}
-                  onChange={(e) => setArenaDescription(e.target.value)}
-                  placeholder="Short mission brief"
-                />
+            <section className="card">
+              <div className="card-header">
+                <h2>Add Arena</h2>
+                <span className="muted">Deploy</span>
+              </div>
+              <form onSubmit={handleCreateArena}>
+                <fieldset disabled={formsDisabled} className="fieldset">
+                  <label htmlFor="arena-name">Name</label>
+                  <input
+                    id="arena-name"
+                    value={arenaName}
+                    onChange={(e) => setArenaName(e.target.value)}
+                    placeholder="e.g. Forge Alpha"
+                    required
+                  />
 
-                <label htmlFor="arena-capacity">Capacity (optional)</label>
-                <input
-                  id="arena-capacity"
-                  type="number"
-                  value={arenaCapacity}
-                  onChange={(e) => setArenaCapacity(e.target.value)}
-                  min="0"
-                  placeholder="Max agents"
-                />
+                  <label htmlFor="arena-description">Description</label>
+                  <input
+                    id="arena-description"
+                    value={arenaDescription}
+                    onChange={(e) => setArenaDescription(e.target.value)}
+                    placeholder="Short mission brief"
+                  />
 
-                <button className="button" type="submit">
-                  Create Arena
-                </button>
-              </fieldset>
-            </form>
-          </section>
-        </div>
+                  <label htmlFor="arena-capacity">Capacity (optional)</label>
+                  <input
+                    id="arena-capacity"
+                    type="number"
+                    value={arenaCapacity}
+                    onChange={(e) => setArenaCapacity(e.target.value)}
+                    min="0"
+                    placeholder="Max agents"
+                  />
 
-        <div className="grid" style={{ gap: 24 }}>
-          <section className="card">
-            <div className="card-header">
-              <h2>Current Players</h2>
-              <span className="muted">Roster</span>
-            </div>
-            {playersLoading ? (
-              <ul className="list">
-                {Array.from({ length: 4 }).map((_, index) => (
-                  <li key={index}>
-                    <span className="skel" style={{ width: 160 }} />
-                    <span className="skel" style={{ width: 90 }} />
-                  </li>
-                ))}
-              </ul>
-            ) : players.length === 0 ? (
-              <p className="empty">No players created yet.</p>
-            ) : (
-              <ul className="list">
-                {players.map((p) => (
-                  <li key={p.id}>
-                    <div className="meta-grid">
-                      <strong>{p.codename}</strong>
-                      {p.lastActiveAt ? (
-                        <span className="muted">Last active {new Date(p.lastActiveAt).toLocaleString()}</span>
-                      ) : (
-                        <span className="muted">Created {new Date(p.createdAt).toLocaleString()}</span>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
+                  <button className="button" type="submit">
+                    Create Arena
+                  </button>
+                </fieldset>
+              </form>
+            </section>
+          </div>
 
-          <section className="card">
-            <div className="card-header">
-              <h2>Current Arenas</h2>
-              <span className="muted">Live grid</span>
-            </div>
-            {arenasError ? (
-              <div className="error">Failed to load arenas.</div>
-            ) : arenasLoading ? (
-              <ul className="list">
-                {Array.from({ length: 3 }).map((_, index) => (
-                  <li key={index}>
-                    <span className="skel" style={{ width: 140 }} />
-                    <span className="skel" style={{ width: 110 }} />
-                  </li>
-                ))}
-              </ul>
-            ) : arenas.length === 0 ? (
-              <p className="empty">No arenas created yet.</p>
-            ) : (
-              <ul className="list">
-                {arenas.map((arena) => (
-                  <li key={arena.id}>
-                    <div className="meta-grid">
-                      <strong>{arena.name}</strong>
-                      {arena.description ? <span className="muted">{arena.description}</span> : null}
-                    </div>
-                    <div className="meta">
-                      {arena.capacity ? (
-                        <span className="muted">Capacity {arena.capacity}</span>
-                      ) : (
-                        <span className="muted">Capacity ∞</span>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
+          <div className="grid" style={{ gap: 24 }}>
+            <section className="card">
+              <div className="card-header">
+                <h2>Current Players</h2>
+                <span className="muted">Roster</span>
+              </div>
+              {playersLoading ? (
+                <ul className="list">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <li key={index}>
+                      <span className="skel" style={{ width: 160 }} />
+                      <span className="skel" style={{ width: 90 }} />
+                    </li>
+                  ))}
+                </ul>
+              ) : players.length === 0 ? (
+                <p className="empty">No players created yet.</p>
+              ) : (
+                <ul className="list">
+                  {players.map((p) => (
+                    <li key={p.id}>
+                      <div className="meta-grid">
+                        <strong>{p.codename}</strong>
+                        {p.lastActiveAt ? (
+                          <span className="muted">Last active {new Date(p.lastActiveAt).toLocaleString()}</span>
+                        ) : (
+                          <span className="muted">Created {new Date(p.createdAt).toLocaleString()}</span>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section className="card">
+              <div className="card-header">
+                <h2>Current Arenas</h2>
+                <span className="muted">Live grid</span>
+              </div>
+              {arenasError ? (
+                <div className="error">Failed to load arenas.</div>
+              ) : arenasLoading ? (
+                <ul className="list">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <li key={index}>
+                      <span className="skel" style={{ width: 140 }} />
+                      <span className="skel" style={{ width: 110 }} />
+                    </li>
+                  ))}
+                </ul>
+              ) : arenas.length === 0 ? (
+                <p className="empty">No arenas created yet.</p>
+              ) : (
+                <ul className="list">
+                  {arenas.map((arena) => (
+                    <li key={arena.id}>
+                      <div className="meta-grid">
+                        <strong>{arena.name}</strong>
+                        {arena.description ? <span className="muted">{arena.description}</span> : null}
+                      </div>
+                      <div className="meta">
+                        {arena.capacity ? (
+                          <span className="muted">Capacity {arena.capacity}</span>
+                        ) : (
+                          <span className="muted">Capacity ∞</span>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
         </div>
       </div>
-      </div>
-      <DebugDock />
-    </>
+    <DebugDock />
+  </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add callable adminDeleteArena and adminDeletePlayer functions that validate admin claims and delete related data safely
- expose client helpers and an AdminControls panel to trigger arena or player deletion when the signed-in token has admin access
- tighten Firestore rules so only admin tokens can delete arena root documents

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2098ceddc832e924e7278156bd116