### PR TITLE
Implement presence teardown, writer lease, and admin logging

### DIFF
--- a/src/game/net/hostLoop.test.ts
+++ b/src/game/net/hostLoop.test.ts
@@ -53,12 +53,14 @@ describe("startHostLoop", () => {
         id: "p1",
         presenceId: "p1",
         authUid: "p1",
+        uid: "p1",
         lastSeen: new Date().toISOString(),
       } as LivePresence,
       {
         id: "p2",
         presenceId: "p2",
         authUid: "p2",
+        uid: "p2",
         lastSeen: new Date().toISOString(),
       } as LivePresence,
     ];


### PR DESCRIPTION
## Summary
- align arena presence with auth IDs, pause the heartbeat when hidden, and best-effort delete docs on page exit
- watch arena state to elect writers by uid and manage a Firestore lease with transaction-based claims and renewals
- add admin delete actions with confirmation prompts plus a copyable debug log of all create/delete outcomes

## Testing
- pnpm run typecheck
- pnpm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2118adfdc832e930223fc572f9348