### PR TITLE
Fix arena route param typing

### DIFF
--- a/src/pages/ArenaPage.tsx
+++ b/src/pages/ArenaPage.tsx
@@ -19,8 +19,8 @@ const DEFAULT_SPAWN = {
 
 export default function ArenaPage() {
   // Route param is /arena/:id — default to CLIFF and normalize to uppercase.
-  const params = useParams<{ id?: string }>();
-  const arenaId = (params.id ?? "CLIFF").toUpperCase();
+  const { arenaId: routeArenaId } = useParams<{ arenaId?: string }>();
+  const arenaId = (routeArenaId ?? "CLIFF").toUpperCase();
 
   // Auth (for display/codename only)
   const { user, player } = useAuth();


### PR DESCRIPTION
## Summary
- update ArenaPage to destructure the `arenaId` param with typing
- continue normalizing the route arena id to uppercase with CLIFF fallback

## Testing
- pnpm test -- --filter arena

------
https://chatgpt.com/codex/tasks/task_e_68d2be0331b4832eae0803d6c2ec251c